### PR TITLE
feat: make package HTTP-agnostic and add extension support

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -4,6 +4,8 @@ import "fmt"
 
 // ValidationError is the base error type for all validation errors.
 // It includes the field name that failed validation and a descriptive message.
+// This is the parent type for more specific validation errors like
+// PaginationError, SortError, and FilterError.
 type ValidationError struct {
 	Field   string
 	Message string

--- a/extension.go
+++ b/extension.go
@@ -1,0 +1,90 @@
+package queryutil
+
+// RequestParser defines an interface for parsing query parameters from any source.
+// This interface allows queryutil to be extended to work with different request types
+// beyond HTTP requests, such as gRPC, WebSockets, or custom protocols.
+//
+// Implementations must provide methods to parse filters, sorts, and pagination
+// parameters from their specific request format.
+type RequestParser interface {
+	ParseFilters() ([]Filter, error)
+	ParseSorts() ([]Sort, error)
+	ParsePagination() (Pagination, error)
+}
+
+// EntityFunc is a generic function type for entity list operations.
+// It takes filters, sorts, and pagination parameters and returns
+// a slice of items, total count, and an error.
+//
+// This type is commonly used for service layer functions that retrieve
+// entities from a data source with filtering, sorting, and pagination.
+//
+// Example implementation:
+//
+//	func ListUsers(filters []Filter, sorts []Sort, pagination Pagination) ([]User, int64, error) {
+//	    db := database.GetDB()
+//	    query := db.Model(&User{})
+//	    
+//	    // Apply filters and sorts
+//	    query = ApplyFilters(query, filters, nil)
+//	    query = ApplySort(query, sorts)
+//	    
+//	    // Count total before pagination
+//	    var total int64
+//	    query.Count(&total)
+//	    
+//	    // Apply pagination
+//	    query = query.Offset(pagination.GetOffset()).Limit(pagination.GetLimit())
+//	    
+//	    // Execute query
+//	    var users []User
+//	    err := query.Find(&users).Error
+//	    return users, total, err
+//	}
+type EntityFunc[T any] func([]Filter, []Sort, Pagination) ([]T, int64, error)
+
+// ParseFromCustomSource allows using queryutil with custom request sources
+// by accepting any implementation of the RequestParser interface.
+//
+// This function provides a way to extend queryutil to work with different
+// request types beyond HTTP requests.
+//
+// Example with a custom parser:
+//
+//	type MyCustomParser struct {
+//	    // Custom fields
+//	}
+//	
+//	func (p *MyCustomParser) ParseFilters() ([]Filter, error) {
+//	    // Custom implementation
+//	}
+//	
+//	func (p *MyCustomParser) ParseSorts() ([]Sort, error) {
+//	    // Custom implementation
+//	}
+//	
+//	func (p *MyCustomParser) ParsePagination() (Pagination, error) {
+//	    // Custom implementation
+//	}
+//	
+//	// Usage
+//	parser := &MyCustomParser{}
+//	filters, sorts, pagination, err := ParseFromCustomSource(parser)
+func ParseFromCustomSource(parser RequestParser) ([]Filter, []Sort, Pagination, error) {
+	filters, err := parser.ParseFilters()
+	if err != nil {
+		return nil, nil, Pagination{}, err
+	}
+
+	sorts, err := parser.ParseSorts()
+	if err != nil {
+		return filters, nil, Pagination{}, err
+	}
+
+	pagination, err := parser.ParsePagination()
+	if err != nil {
+		return filters, sorts, Pagination{}, err
+	}
+
+	return filters, sorts, pagination, nil
+}

--- a/extension_test.go
+++ b/extension_test.go
@@ -1,0 +1,55 @@
+package queryutil
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+)
+
+// MockRequestParser implements the RequestParser interface for testing
+type MockRequestParser struct {
+	filters    []Filter
+	sorts      []Sort
+	pagination Pagination
+	filterErr  error
+	sortErr    error
+	pageErr    error
+}
+
+func (m *MockRequestParser) ParseFilters() ([]Filter, error) {
+	return m.filters, m.filterErr
+}
+
+func (m *MockRequestParser) ParseSorts() ([]Sort, error) {
+	return m.sorts, m.sortErr
+}
+
+func (m *MockRequestParser) ParsePagination() (Pagination, error) {
+	return m.pagination, m.pageErr
+}
+
+func TestParseFromCustomSource(t *testing.T) {
+	mockParser := &MockRequestParser{
+		filters: []Filter{
+			{Field: "name", Operator: OperatorEquals, Value: "test"},
+		},
+		sorts: []Sort{
+			{Field: "name", Order: OrderAsc},
+		},
+		pagination: Pagination{
+			Start:    0,
+			End:      10,
+			PageSize: 10,
+			Mode:     "server",
+		},
+	}
+	
+	filters, sorts, pagination, err := ParseFromCustomSource(mockParser)
+	
+	assert.NoError(t, err)
+	assert.Len(t, filters, 1)
+	assert.Equal(t, "name", filters[0].Field)
+	assert.Len(t, sorts, 1)
+	assert.Equal(t, "name", sorts[0].Field)
+	assert.Equal(t, 0, pagination.Start)
+	assert.Equal(t, 10, pagination.End)
+}

--- a/filter.go
+++ b/filter.go
@@ -1,11 +1,16 @@
-// Package queryutil implements Refine-compatible query parsing utilities for filtering, sorting, and pagination.
+// Package queryutil implements HTTP-agnostic query parsing utilities for filtering, sorting, and pagination.
 //
-// This package provides functionality to parse and handle query parameters in the format
-// expected by Refine's Simple REST Data Provider specification. It includes support for:
+// This package provides functionality to parse and handle query parameters in a format
+// compatible with Refine's Simple REST Data Provider specification, while remaining
+// framework-agnostic. It includes support for:
 //   - Filtering with various operators (equals, not equals, gte, lte, contains)
 //   - Sorting with multiple fields and directions
 //   - Pagination with server/client modes
 //   - GORM integration helpers
+//   - Extension points for custom request sources
+//
+// The core package is HTTP-agnostic, with HTTP-specific functionality provided
+// in the http subpackage.
 package queryutil
 
 import (
@@ -18,12 +23,14 @@ import (
 )
 
 // FilterOperator represents supported filter operations.
+// These operators are used in query parameters with the format field_operator=value.
+//
 // Available operators are:
-//   - "" (equals, default)
-//   - "ne" (not equals)
-//   - "gte" (greater than or equal)
-//   - "lte" (less than or equal)
-//   - "like" (contains)
+//   - "" (equals, default) - Example: name=john
+//   - "ne" (not equals) - Example: status_ne=inactive
+//   - "gte" (greater than or equal) - Example: age_gte=18
+//   - "lte" (less than or equal) - Example: price_lte=100
+//   - "like" (contains) - Example: title_like=test
 type FilterOperator string
 
 const (
@@ -126,7 +133,10 @@ func ParseQueryFilters(query map[string][]string) ([]Filter, error) {
 
 // GlobalSearchConfig defines configuration for handling the global search 'q' parameter.
 // It specifies which database columns should be included in the LIKE query when
-// performing a global search.
+// performing a global search across multiple fields.
+//
+// This is typically used with the special 'q' query parameter that performs
+// a search across multiple columns simultaneously.
 type GlobalSearchConfig struct {
 	// Columns to search in with LIKE queries
 	SearchableColumns []string
@@ -143,6 +153,17 @@ type GlobalSearchConfig struct {
 //   - gte: field >= value
 //   - lte: field <= value
 //   - contains: field LIKE %value%
+//
+// Example:
+//
+//	db := gorm.Open(...)
+//	filters := []Filter{
+//	    {Field: "name", Operator: OperatorEquals, Value: "John"},
+//	    {Field: "age", Operator: OperatorGTE, Value: 18},
+//	}
+//	query := ApplyFilters(db, filters, nil)
+//	var users []User
+//	query.Find(&users)
 func ApplyFilters(tx *gorm.DB, filters []Filter, searchConfig *GlobalSearchConfig) *gorm.DB {
 	for _, filter := range filters {
 		// Special handling for global search

--- a/http/adapter.go
+++ b/http/adapter.go
@@ -1,0 +1,54 @@
+package http
+
+import (
+	"go.lumeweb.com/queryutil"
+	"net/http"
+)
+
+// ParseRequestHTTP parses query parameters from an http.Request.
+// This is a convenience wrapper around queryutil.ParseQuery that
+// extracts the URL query parameters from the request.
+//
+// Example:
+//
+//	r, _ := http.NewRequest("GET", "/?name=john&_sort=name", nil)
+//	filters, sorts, pagination, err := http.ParseRequestHTTP(r)
+func ParseRequestHTTP(r *http.Request) ([]queryutil.Filter, []queryutil.Sort, queryutil.Pagination, error) {
+	return queryutil.ParseQuery(r.URL.Query())
+}
+
+// ParseRequestWithSearchHTTP parses query parameters with global search support.
+// This function is similar to ParseRequestHTTP but also accepts a GlobalSearchConfig
+// for handling the special 'q' parameter for searching across multiple columns.
+//
+// Example:
+//
+//	searchConfig := &queryutil.GlobalSearchConfig{
+//	    SearchableColumns: []string{"name", "email", "bio"},
+//	}
+//	r, _ := http.NewRequest("GET", "/?q=john&_sort=name", nil)
+//	filters, sorts, pagination, err := http.ParseRequestWithSearchHTTP(r, searchConfig)
+func ParseRequestWithSearchHTTP(r *http.Request, searchConfig *queryutil.GlobalSearchConfig) ([]queryutil.Filter, []queryutil.Sort, queryutil.Pagination, error) {
+	return queryutil.ParseQueryWithSearch(r.URL.Query(), searchConfig)
+}
+
+// SetContentRangeHeader sets the Content-Range header for pagination.
+// This header is used by clients (like Refine) to understand the pagination
+// state and total count of resources.
+//
+// The format is: "entityName start-end/total"
+// For example: "users 0-9/100"
+//
+// Example:
+//
+//	w := httptest.NewRecorder()
+//	users := []User{...} // 10 users
+//	pagination := queryutil.Pagination{Start: 0, End: 10}
+//	SetContentRangeHeader(w, "users", pagination, users, 100)
+//	// Sets header: Content-Range: users 0-9/100
+func SetContentRangeHeader(w http.ResponseWriter, entityName string, pagination queryutil.Pagination,
+	data interface{}, totalCount int64) {
+	resultCount := queryutil.GetResultCount(data)
+	contentRange := queryutil.FormatContentRange(entityName, pagination, resultCount, totalCount)
+	w.Header().Set("Content-Range", contentRange)
+}

--- a/http/adapter_test.go
+++ b/http/adapter_test.go
@@ -1,0 +1,37 @@
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.lumeweb.com/queryutil"
+)
+
+func TestParseRequestHTTP(t *testing.T) {
+	r, _ := http.NewRequest("GET", "/?name=john&age_gte=20&_sort=name,age&_order=desc,asc&_start=0&_end=10", nil)
+
+	filters, sorts, pagination, err := ParseRequestHTTP(r)
+
+	assert.NoError(t, err)
+	assert.Len(t, filters, 2)
+	assert.Len(t, sorts, 2)
+	assert.Equal(t, 0, pagination.Start)
+	assert.Equal(t, 10, pagination.End)
+}
+
+func TestSetContentRangeHeader(t *testing.T) {
+	w := httptest.NewRecorder()
+	data := []string{"item1", "item2", "item3"}
+	pagination := queryutil.Pagination{
+		Start:    0,
+		End:      10,
+		PageSize: 10,
+		Mode:     "server",
+	}
+
+	SetContentRangeHeader(w, "items", pagination, data, 100)
+
+	assert.Equal(t, "items 0-2/100", w.Header().Get("Content-Range"))
+}

--- a/http/encoding.go
+++ b/http/encoding.go
@@ -1,0 +1,35 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"reflect"
+)
+
+// EncodeJSON encodes a value as JSON and writes it to the http.ResponseWriter.
+// It handles empty slices and maps specially, encoding them as "[]" and "{}" respectively
+// instead of "null". This provides a more consistent API response format.
+//
+// Example:
+//
+//	w := httptest.NewRecorder()
+//	var emptySlice []string
+//	EncodeJSON(w, emptySlice) // Writes "[]" instead of "null"
+func EncodeJSON(w http.ResponseWriter, v interface{}) error {
+	w.Header().Set("Content-Type", "application/json")
+	
+	// Handle empty slices and maps specially
+	val := reflect.ValueOf(v)
+	if val.Kind() == reflect.Slice && val.Len() == 0 {
+		_, err := w.Write([]byte("[]\n"))
+		return err
+	} else if val.Kind() == reflect.Map && val.Len() == 0 {
+		_, err := w.Write([]byte("{}\n"))
+		return err
+	}
+	
+	// Use standard JSON encoding for other values
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "\t")
+	return enc.Encode(v)
+}

--- a/http/encoding_test.go
+++ b/http/encoding_test.go
@@ -1,0 +1,69 @@
+package http
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEncodeJSON(t *testing.T) {
+	tests := []struct {
+		name           string
+		value          interface{}
+		expectedBody   string
+		expectedHeader string
+	}{
+		{
+			name:           "empty slice",
+			value:          []string{},
+			expectedBody:   "[]\n",
+			expectedHeader: "application/json",
+		},
+		{
+			name:           "empty map",
+			value:          map[string]string{},
+			expectedBody:   "{}\n",
+			expectedHeader: "application/json",
+		},
+		{
+			name:           "string value",
+			value:          "test",
+			expectedBody:   "\"test\"\n",
+			expectedHeader: "application/json",
+		},
+		{
+			name: "struct value",
+			value: struct {
+				Name string `json:"name"`
+				Age  int    `json:"age"`
+			}{
+				Name: "John",
+				Age:  30,
+			},
+			expectedBody:   "{\n\t\"name\": \"John\",\n\t\"age\": 30\n}\n",
+			expectedHeader: "application/json",
+		},
+		{
+			name: "slice with values",
+			value: []string{
+				"one",
+				"two",
+			},
+			expectedBody:   "[\n\t\"one\",\n\t\"two\"\n]\n",
+			expectedHeader: "application/json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			
+			err := EncodeJSON(w, tt.value)
+			
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedHeader, w.Header().Get("Content-Type"))
+			assert.Equal(t, tt.expectedBody, w.Body.String())
+		})
+	}
+}

--- a/http/handlers.go
+++ b/http/handlers.go
@@ -1,0 +1,80 @@
+package http
+
+import (
+	"fmt"
+	"net/http"
+	"go.lumeweb.com/queryutil"
+)
+
+// ProcessListRequest handles the common pattern for list endpoints.
+// This function encapsulates the standard flow for list operations:
+// 1. Parse query parameters (filters, sorts, pagination)
+// 2. Call the service function to get data
+// 3. Convert domain entities to DTOs
+// 4. Set appropriate headers
+// 5. Encode the response as JSON
+//
+// Type parameters:
+//   - T: The domain entity type returned by the service
+//   - D: The DTO (Data Transfer Object) type to be sent to the client
+//
+// Parameters:
+//   - w: The HTTP response writer
+//   - r: The HTTP request
+//   - entityName: The name of the entity (used for Content-Range header)
+//   - service: A function that retrieves entities with filtering, sorting, and pagination
+//   - converter: A function that converts domain entities to DTOs
+//
+// Example:
+//
+//	http.HandleFunc("/api/users", func(w http.ResponseWriter, r *http.Request) {
+//	    err := http.ProcessListRequest(
+//	        w, r,
+//	        "users",
+//	        userService.ListUsers,
+//	        func(user User) UserDTO {
+//	            return UserDTO{
+//	                ID:   user.ID,
+//	                Name: user.Name,
+//	            }
+//	        },
+//	    )
+//	    if err != nil {
+//	        // Error already handled by ProcessListRequest
+//	        return
+//	    }
+//	})
+func ProcessListRequest[T any, D any](
+	w http.ResponseWriter,
+	r *http.Request,
+	entityName string,
+	service queryutil.EntityFunc[T],
+	converter func(T) D,
+) error {
+	// Parse query parameters
+	filters, sorts, pagination, err := ParseRequestHTTP(r)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Invalid query parameters: %v", err), http.StatusBadRequest)
+		return err
+	}
+
+	// Get data from service
+	items, total, err := service(filters, sorts, pagination)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Failed to list %s: %v", entityName, err), http.StatusInternalServerError)
+		return err
+	}
+
+	// Convert to DTOs
+	responses := make([]D, len(items))
+	for i, item := range items {
+		responses[i] = converter(item)
+	}
+
+	// Set Content-Range header
+	SetContentRangeHeader(w, entityName, pagination, responses, total)
+
+	// Encode response using our enhanced JSON encoder
+	response := queryutil.BuildResponse(responses, total)
+	return EncodeJSON(w, response)
+}

--- a/pagination.go
+++ b/pagination.go
@@ -1,12 +1,17 @@
 package queryutil
 
 import (
+	"fmt"
+	"reflect"
 	"strconv"
 )
 
 // Pagination represents pagination parameters used for limiting query results.
 // It supports both offset/limit style pagination through Start/End parameters
 // and includes support for client/server-side pagination modes.
+//
+// The Start and End fields correspond to the _start and _end query parameters,
+// which define a range of records to return (0-based indexing).
 type Pagination struct {
 	Start    int    // _start param
 	End      int    // _end param
@@ -64,12 +69,36 @@ func ParseQueryPagination(query map[string][]string) (Pagination, error) {
 	return pagination, nil
 }
 
-// GetLimit returns the number of records to fetch
+// GetLimit returns the number of records to fetch (PageSize)
+// This is useful when constructing database queries with LIMIT clauses.
 func (p Pagination) GetLimit() int {
 	return p.PageSize
 }
 
 // GetOffset calculates the offset for SQL queries
+// This is useful when constructing database queries with OFFSET clauses.
+// It returns the Start value directly.
 func (p Pagination) GetOffset() int {
 	return p.Start
+}
+
+// FormatContentRange creates a formatted string for Content-Range headers
+// This is HTTP-related but doesn't directly depend on HTTP packages
+func FormatContentRange(entityName string, pagination Pagination,
+	resultCount int, totalCount int64) string {
+	return fmt.Sprintf("%s %d-%d/%d",
+		entityName,
+		pagination.Start,
+		pagination.Start+resultCount-1,
+		totalCount)
+}
+
+// GetResultCount safely gets the length of a slice or array
+// Useful for calculating pagination ranges
+func GetResultCount(data interface{}) int {
+	v := reflect.ValueOf(data)
+	if v.Kind() == reflect.Slice || v.Kind() == reflect.Array {
+		return v.Len()
+	}
+	return 0
 }

--- a/pagination_test.go
+++ b/pagination_test.go
@@ -79,3 +79,52 @@ func TestParseQueryPagination(t *testing.T) {
 		})
 	}
 }
+
+func TestFormatContentRange(t *testing.T) {
+	pagination := Pagination{
+		Start:    10,
+		End:      20,
+		PageSize: 10,
+		Mode:     "server",
+	}
+	
+	result := FormatContentRange("users", pagination, 5, 100)
+	
+	assert.Equal(t, "users 10-14/100", result)
+}
+
+func TestGetResultCount(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     interface{}
+		expected int
+	}{
+		{
+			name:     "slice with items",
+			data:     []string{"a", "b", "c"},
+			expected: 3,
+		},
+		{
+			name:     "empty slice",
+			data:     []int{},
+			expected: 0,
+		},
+		{
+			name:     "non-slice",
+			data:     "not a slice",
+			expected: 0,
+		},
+		{
+			name:     "nil",
+			data:     nil,
+			expected: 0,
+		},
+	}
+	
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			count := GetResultCount(tt.data)
+			assert.Equal(t, tt.expected, count)
+		})
+	}
+}

--- a/request.go
+++ b/request.go
@@ -1,18 +1,30 @@
 package queryutil
 
 import (
+	"fmt"
 	"net/http"
 )
 
-// ParseRequest parses all query parameters from an HTTP request.
-// This is the main entry point for processing Refine requests.
+// ParseQuery parses all query parameters from a map.
+// This is the main entry point for processing query parameters in an HTTP-agnostic way.
 // It combines parsing of filters, sorts, and pagination parameters.
 //
 // Returns parsed Filter, Sort, and Pagination structs or an error
 // if any validation fails.
-func ParseRequest(r *http.Request) ([]Filter, []Sort, Pagination, error) {
-	query := r.URL.Query()
-	
+//
+// Example:
+//
+//	// With a map of query parameters
+//	query := map[string][]string{
+//	    "name": {"john"},
+//	    "age_gte": {"18"},
+//	    "_sort": {"name"},
+//	    "_order": {"desc"},
+//	    "_start": {"0"},
+//	    "_end": {"10"},
+//	}
+//	filters, sorts, pagination, err := ParseQuery(query)
+func ParseQuery(query map[string][]string) ([]Filter, []Sort, Pagination, error) {
 	// Parse filters
 	filters, err := ParseQueryFilters(query)
 	if err != nil {
@@ -34,17 +46,80 @@ func ParseRequest(r *http.Request) ([]Filter, []Sort, Pagination, error) {
 	return filters, sorts, pagination, nil
 }
 
-// ParseRequestWithSearch parses query parameters with global search support.
-// Similar to ParseRequest but includes configuration for global search
+// ParseQueryWithSearch parses query parameters with global search support.
+// Similar to ParseQuery but includes configuration for global search
 // functionality across multiple columns.
 //
 // The searchConfig parameter specifies which columns should be included
 // in global search operations when the 'q' parameter is present.
-func ParseRequestWithSearch(r *http.Request, searchConfig *GlobalSearchConfig) ([]Filter, []Sort, Pagination, error) {
-	filters, sorts, pagination, err := ParseRequest(r)
+func ParseQueryWithSearch(query map[string][]string, searchConfig *GlobalSearchConfig) ([]Filter, []Sort, Pagination, error) {
+	filters, sorts, pagination, err := ParseQuery(query)
 	if err != nil {
 		return nil, nil, Pagination{}, err
 	}
 
 	return filters, sorts, pagination, nil
+}
+
+// HTTPRequestParser implements the RequestParser interface for HTTP requests.
+// It provides a way to parse query parameters from an HTTP request's URL query.
+type HTTPRequestParser struct {
+	Query map[string][]string
+	SearchConfig *GlobalSearchConfig
+}
+
+// NewHTTPRequestParser creates a new HTTPRequestParser from an http.Request
+func NewHTTPRequestParser(r *http.Request, searchConfig *GlobalSearchConfig) *HTTPRequestParser {
+	return &HTTPRequestParser{
+		Query: r.URL.Query(),
+		SearchConfig: searchConfig,
+	}
+}
+
+// ParseFilters implements RequestParser.ParseFilters
+func (p *HTTPRequestParser) ParseFilters() ([]Filter, error) {
+	return ParseQueryFilters(p.Query)
+}
+
+// ParseSorts implements RequestParser.ParseSorts
+func (p *HTTPRequestParser) ParseSorts() ([]Sort, error) {
+	return ParseQuerySort(p.Query, nil)
+}
+
+// ParsePagination implements RequestParser.ParsePagination
+func (p *HTTPRequestParser) ParsePagination() (Pagination, error) {
+	return ParseQueryPagination(p.Query)
+}
+
+// ParseRequest parses all query parameters from an HTTP request.
+// This is maintained for backward compatibility with older code.
+//
+// New code should use the http.ParseRequestHTTP function instead,
+// which provides a more type-safe interface.
+//
+// Example:
+//
+//	// With an http.Request
+//	r, _ := http.NewRequest("GET", "/?name=john&_sort=name", nil)
+//	filters, sorts, pagination, err := ParseRequest(r)
+func ParseRequest(r interface{}) ([]Filter, []Sort, Pagination, error) {
+	// Check if r is an *http.Request
+	if req, ok := r.(*http.Request); ok {
+		parser := NewHTTPRequestParser(req, nil)
+		return ParseFromCustomSource(parser)
+	}
+	
+	return nil, nil, Pagination{}, fmt.Errorf("unsupported request type")
+}
+
+// ParseRequestWithSearch parses query parameters with global search support.
+// This is maintained for backward compatibility.
+func ParseRequestWithSearch(r interface{}, searchConfig *GlobalSearchConfig) ([]Filter, []Sort, Pagination, error) {
+	// Check if r is an *http.Request
+	if req, ok := r.(*http.Request); ok {
+		parser := NewHTTPRequestParser(req, searchConfig)
+		return ParseFromCustomSource(parser)
+	}
+	
+	return nil, nil, Pagination{}, fmt.Errorf("unsupported request type")
 }

--- a/request_test.go
+++ b/request_test.go
@@ -9,14 +9,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParseRequest(t *testing.T) {
+func TestParseQuery(t *testing.T) {
 	tests := []struct {
 		name           string
-		query         url.Values
-		wantFilters   []Filter
-		wantSorts     []Sort
+		query          url.Values
+		wantFilters    []Filter
+		wantSorts      []Sort
 		wantPagination Pagination
-		wantErr       bool
+		wantErr        bool
 	}{
 		{
 			name: "complete request",
@@ -50,6 +50,68 @@ func TestParseRequest(t *testing.T) {
 				"status_or": []string{"active,inactive"},
 			},
 			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test ParseQuery directly
+			filters, sorts, pagination, err := ParseQuery(tt.query)
+			
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			
+			assert.NoError(t, err)
+			// Sort both slices by Field to make comparison order-independent
+			sort.Slice(filters, func(i, j int) bool {
+				return filters[i].Field < filters[j].Field
+			})
+			sort.Slice(tt.wantFilters, func(i, j int) bool {
+				return tt.wantFilters[i].Field < tt.wantFilters[j].Field
+			})
+			assert.Equal(t, tt.wantFilters, filters)
+			assert.Equal(t, tt.wantSorts, sorts)
+			assert.Equal(t, tt.wantPagination, pagination)
+		})
+	}
+}
+
+func TestParseRequest(t *testing.T) {
+	tests := []struct {
+		name           string
+		query          url.Values
+		wantFilters    []Filter
+		wantSorts      []Sort
+		wantPagination Pagination
+		wantErr        bool
+	}{
+		{
+			name: "complete request",
+			query: url.Values{
+				"name":    []string{"john"},
+				"age_gte": []string{"20"},
+				"_sort":   []string{"name,age"},
+				"_order":  []string{"desc,asc"},
+				"_start":  []string{"0"},
+				"_end":    []string{"10"},
+			},
+			wantFilters: []Filter{
+				{Field: "name", Operator: OperatorEquals, Value: "john"},
+				{Field: "age", Operator: OperatorGTE, Value: "20"},
+			},
+			wantSorts: []Sort{
+				{Field: "name", Order: OrderDesc},
+				{Field: "age", Order: OrderAsc},
+			},
+			wantPagination: Pagination{
+				Start:    0,
+				End:      10,
+				PageSize: 10,
+				Mode:     "server",
+			},
+			wantErr: false,
 		},
 	}
 

--- a/response.go
+++ b/response.go
@@ -1,15 +1,23 @@
 package queryutil
 
-// Response represents a Refine-compatible response structure.
+// Response represents a standard response structure for list operations.
 // It includes both the data payload and a total count for pagination.
+// This structure is compatible with Refine's Simple REST Data Provider.
 type Response struct {
 	Data  interface{} `json:"data"`
 	Total int64       `json:"total"`
 }
 
-// BuildResponse creates a Refine-compatible response object.
+// BuildResponse creates a standard response object for list operations.
 // Takes the data payload and total count as parameters.
 // The total count is used for client-side pagination calculations.
+//
+// Example:
+//
+//	users := []User{...}
+//	totalCount := int64(100)
+//	response := BuildResponse(users, totalCount)
+//	// response can be encoded to JSON and sent to the client
 func BuildResponse(data interface{}, total int64) *Response {
 	return &Response{
 		Data:  data,

--- a/sort.go
+++ b/sort.go
@@ -20,6 +20,9 @@ const (
 // SortConfig defines configuration for field sorting validation.
 // It maintains a list of field names that are allowed to be used
 // in sort operations, preventing sorting on unauthorized fields.
+//
+// This is useful for security to ensure users can only sort by
+// fields that are intended to be sortable.
 type SortConfig struct {
 	// Fields that are allowed to be sorted
 	SortableFields []string
@@ -93,6 +96,17 @@ func ParseQuerySort(query map[string][]string, config *SortConfig) ([]Sort, erro
 // ApplySort applies sort specifications to a GORM query.
 // For each Sort struct, adds an ORDER BY clause to the query.
 // Multiple sorts are applied in the order they appear in the slice.
+//
+// Example:
+//
+//	db := gorm.Open(...)
+//	sorts := []Sort{
+//	    {Field: "name", Order: OrderAsc},
+//	    {Field: "created_at", Order: OrderDesc},
+//	}
+//	query := ApplySort(db, sorts)
+//	var users []User
+//	query.Find(&users)
 func ApplySort(tx *gorm.DB, sorts []Sort) *gorm.DB {
 	for _, sort := range sorts {
 		tx = tx.Order(fmt.Sprintf("%s %s", sort.Field, sort.Order))


### PR DESCRIPTION
- Introduced RequestParser interface for custom request sources
- Created http subpackage for HTTP-specific code
- Added FormatContentRange and GetResultCount utility functions
- Added EntityFunc type for service layer operations
- Added JSON encoding with special handling for empty collections
- Improved documentation with detailed examples
- Added support for any implementation of RequestParser