### PR TITLE
feat(filter): enhance CrudFilter interface with typed getters and validation

### DIFF
--- a/filter/core.go
+++ b/filter/core.go
@@ -23,6 +23,12 @@ type Visitor interface {
 type CrudFilter interface {
 	// AcceptVisitor enables the visitor pattern for filter evaluation
 	AcceptVisitor(Visitor) (Clause, error)
+	// GetOperator returns the filter's operator (for both logical and conditional filters)
+	GetOperator() string
+	// GetField returns the field name (empty string for conditional filters)
+	GetField() string
+	// GetFilters returns nested filters for conditional types (empty for logical filters)
+	GetFilters() []CrudFilter
 }
 
 // Clause represents a compiled filter expression ready for execution
@@ -50,14 +56,46 @@ func (f *LogicalFilter) AcceptVisitor(v Visitor) (Clause, error) {
 	return v.VisitLogical(f)
 }
 
+func (f *LogicalFilter) GetOperator() string {
+	return string(f.Operator)
+}
+
+func (f *LogicalFilter) GetField() string {
+	return f.Field
+}
+
+func (f *LogicalFilter) GetFilters() []CrudFilter {
+	return nil
+}
+
 // ConditionalFilter groups multiple filters with boolean logic
 type ConditionalFilter struct {
 	Operator LogicalOperator `json:"operator"` // AND/OR/NOT combinator
 	Filters  []CrudFilter    `json:"value"`    // Nested filter expressions
 }
 
+// NewConditionalFilter creates a new ConditionalFilter with validation
+func NewConditionalFilter(op LogicalOperator, filters []CrudFilter) CrudFilter {
+	if op == LogicalNot && len(filters) != 1 {
+		panic("NOT operator requires exactly one filter")
+	}
+	return &ConditionalFilter{Operator: op, Filters: filters}
+}
+
 func (f *ConditionalFilter) AcceptVisitor(v Visitor) (Clause, error) {
 	return v.VisitConditional(f)
+}
+
+func (f *ConditionalFilter) GetOperator() string {
+	return string(f.Operator)
+}
+
+func (f *ConditionalFilter) GetField() string {
+	return "" // Conditional filters don't have a field
+}
+
+func (f *ConditionalFilter) GetFilters() []CrudFilter {
+	return f.Filters
 }
 
 // GlobalSearchConfig defines settings for full-text search across multiple columns

--- a/filter/core_test.go
+++ b/filter/core_test.go
@@ -1,0 +1,46 @@
+package filter
+
+import (
+	"testing"
+	
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewConditionalFilter(t *testing.T) {
+	t.Run("valid OR operator with multiple filters", func(t *testing.T) {
+		f1 := &LogicalFilter{Field: "a", Operator: OpEq, Value: 1}
+		f2 := &LogicalFilter{Field: "b", Operator: OpGt, Value: 5}
+		
+		cf := NewConditionalFilter(LogicalOr, []CrudFilter{f1, f2})
+		
+		assert.Equal(t, string(LogicalOr), cf.GetOperator())
+		require.Len(t, cf.GetFilters(), 2)
+		assert.IsType(t, &LogicalFilter{}, cf.GetFilters()[0])
+		assert.IsType(t, &LogicalFilter{}, cf.GetFilters()[1])
+	})
+
+	t.Run("valid NOT operator with single filter", func(t *testing.T) {
+		f := &LogicalFilter{Field: "x", Operator: OpNull, Value: nil}
+		
+		cf := NewConditionalFilter(LogicalNot, []CrudFilter{f})
+		
+		assert.Equal(t, string(LogicalNot), cf.GetOperator())
+		require.Len(t, cf.GetFilters(), 1)
+		assert.IsType(t, &LogicalFilter{}, cf.GetFilters()[0])
+	})
+
+	t.Run("panic on invalid NOT operator usage", func(t *testing.T) {
+		f1 := &LogicalFilter{Field: "a", Operator: OpEq, Value: 1}
+		f2 := &LogicalFilter{Field: "b", Operator: OpNe, Value: 2}
+
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("Expected panic for invalid NOT operator usage")
+			}
+		}()
+
+		// This should panic because NOT has multiple filters
+		NewConditionalFilter(LogicalNot, []CrudFilter{f1, f2})
+	})
+}

--- a/queryutil.go
+++ b/queryutil.go
@@ -18,6 +18,7 @@ type (
 	PaginationError    = filter.PaginationError
 	Filter             = filter.LogicalFilter
 	Operator           = filter.Operator
+	LogicalOperator    = filter.LogicalOperator
 )
 
 // Re-export filter operators as typed constants


### PR DESCRIPTION
- Add GetOperator/GetField/GetFilters methods to CrudFilter interface
- Implement method receivers for LogicalFilter and ConditionalFilter types
- Add NewConditionalFilter constructor with NOT operator validation
- Add comprehensive test coverage for conditional filter behavior
- Re-export LogicalOperator type in root package for consumer usage