### PR TITLE
refactor(filter): enhance type safety and add value accessors

### DIFF
--- a/filter/core.go
+++ b/filter/core.go
@@ -25,7 +25,9 @@ type CrudFilter interface {
 	// AcceptVisitor enables the visitor pattern for filter evaluation
 	AcceptVisitor(Visitor) (Clause, error)
 	// GetOperator returns the filter's operator (for both logical and conditional filters)
-	GetOperator() string
+	GetOperator() Operator
+	// GetValue returns the filter's value
+	GetValue() any
 	// GetField returns the field name (empty string for conditional filters)
 	GetField() string
 	// GetFilters returns nested filters for conditional types (empty for logical filters)
@@ -84,8 +86,13 @@ func (f *LogicalFilter) AcceptVisitor(v Visitor) (Clause, error) {
 	return v.VisitLogical(f)
 }
 
-func (f *LogicalFilter) GetOperator() string {
-	return string(f.Operator())
+func (f *LogicalFilter) GetOperator() Operator {
+	return f.operator
+}
+
+// GetValue returns the filter's comparison value
+func (f *LogicalFilter) GetValue() any {
+	return f.value
 }
 
 func (f *LogicalFilter) GetField() string {
@@ -118,8 +125,13 @@ func (f *ConditionalFilter) AcceptVisitor(v Visitor) (Clause, error) {
 	return v.VisitConditional(f)
 }
 
-func (f *ConditionalFilter) GetOperator() string {
-	return string(f.Operator)
+func (f *ConditionalFilter) GetOperator() Operator {
+	return Operator(f.Operator)
+}
+
+// GetValue returns the nested filters for conditional operators
+func (f *ConditionalFilter) GetValue() any {
+	return f.Filters
 }
 
 func (f *ConditionalFilter) GetField() string {
@@ -206,6 +218,10 @@ var OperatorMap = map[string]Operator{
 
 // OperatorReverseMap provides reverse lookup from Operator to its string representation
 var OperatorReverseMap = lo.Invert(OperatorMap)
+
+func (o Operator) String() string {
+    return string(o)
+}
 
 const (
 	LogicalAnd LogicalOperator = "and"

--- a/filter/core_test.go
+++ b/filter/core_test.go
@@ -14,7 +14,7 @@ func TestNewConditionalFilter(t *testing.T) {
 
 		cf := NewConditionalFilter(LogicalOr, []CrudFilter{f1, f2})
 
-		assert.Equal(t, string(LogicalOr), cf.GetOperator())
+		assert.EqualValues(t, LogicalOr, cf.GetOperator())
 		require.Len(t, cf.GetFilters(), 2)
 		assert.IsType(t, &LogicalFilter{}, cf.GetFilters()[0])
 		assert.IsType(t, &LogicalFilter{}, cf.GetFilters()[1])
@@ -25,7 +25,7 @@ func TestNewConditionalFilter(t *testing.T) {
 
 		cf := NewConditionalFilter(LogicalNot, []CrudFilter{f})
 
-		assert.Equal(t, string(LogicalNot), cf.GetOperator())
+		assert.EqualValues(t, string(LogicalNot), cf.GetOperator())
 		require.Len(t, cf.GetFilters(), 1)
 		assert.IsType(t, &LogicalFilter{}, cf.GetFilters()[0])
 	})

--- a/filter/parser/queryparam_test.go
+++ b/filter/parser/queryparam_test.go
@@ -798,7 +798,7 @@ func TestQueryParamParser_ParseFilters(t *testing.T) {
 					field1 = lf.Field() // Use getter
 				} else if cf, ok := f1.(*filter.ConditionalFilter); ok {
 					// Fallback for ConditionalFilter: sort by operator string
-					field1 = string(cf.GetOperator()) // Use getter
+					field1 = cf.GetOperator().String() // Use getter
 					// Add first child field if available
 					if len(cf.GetFilters()) > 0 { // Use getter
 						if lfc, okc := cf.GetFilters()[0].(*filter.LogicalFilter); okc { // Use getter
@@ -810,8 +810,8 @@ func TestQueryParamParser_ParseFilters(t *testing.T) {
 				if lf, ok := f2.(*filter.LogicalFilter); ok {
 					field2 = lf.Field() // Use getter
 				} else if cf, ok := f2.(*filter.ConditionalFilter); ok {
-					field2 = cf.GetOperator()     // Use getter
-					if len(cf.GetFilters()) > 0 { // Use getter
+					field2 = cf.GetOperator().String() // Use getter
+					if len(cf.GetFilters()) > 0 {      // Use getter
 						if lfc, okc := cf.GetFilters()[0].(*filter.LogicalFilter); okc { // Use getter
 							field2 += ":" + lfc.Field() // Use getter
 						}


### PR DESCRIPTION
- Update CrudFilter interface to return Operator type for GetOperator()
- Add GetValue() method to CrudFilter interface
- Implement type-safe operator handling in LogicalFilter/ConditionalFilter
- Add Operator.String() method for string representation
- Update test assertions to use Operator type comparisons
- Maintain compatibility with existing string-based operator values through type conversion