### PR TITLE
feat: add JSON schema support for query filtering and sorting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,24 +1,119 @@
 module go.lumeweb.com/queryutil
 
-go 1.23.0
+go 1.23.1
 
 toolchain go1.23.7
 
 require (
+	github.com/invopop/jsonschema v0.13.0
 	github.com/samber/lo v1.49.1
 	github.com/stretchr/testify v1.10.0
+	go.lumeweb.com/httputil v0.3.5-0.20250525045623-576ceb578578
 	golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6
 	gorm.io/driver/sqlite v1.5.7
 	gorm.io/gorm v1.25.12
 )
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
+	filippo.io/edwards25519 v1.1.0 // indirect
+	github.com/AfterShip/email-verifier v1.4.1 // indirect
+	github.com/Oudwins/zog v0.18.4 // indirect
+	github.com/aws/aws-sdk-go-v2 v1.36.3 // indirect
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.10 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.34 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.34 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.34 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.3 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.7.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.15 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.15 // indirect
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.78.2 // indirect
+	github.com/aws/smithy-go v1.22.3 // indirect
+	github.com/bahlo/generic-list-go v0.2.0 // indirect
+	github.com/boombuler/barcode v1.0.2 // indirect
+	github.com/buger/jsonparser v1.1.1 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/coreos/go-semver v0.3.1 // indirect
+	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/docker/go-units v0.5.0 // indirect
+	github.com/fsnotify/fsnotify v1.8.0 // indirect
+	github.com/gammazero/deque v1.0.0 // indirect
+	github.com/gammazero/workerpool v1.1.3 // indirect
+	github.com/getkin/kin-openapi v0.132.0 // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/go-co-op/gocron/v2 v2.16.1 // indirect
+	github.com/go-openapi/jsonpointer v0.21.0 // indirect
+	github.com/go-openapi/swag v0.23.0 // indirect
+	github.com/go-sql-driver/mysql v1.9.0 // indirect
+	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
+	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/google/uuid v1.6.0 // indirect
+	github.com/gookit/event v1.1.2 // indirect
+	github.com/gorilla/mux v1.8.2-0.20240619235004-db9d1d0073d2 // indirect
+	github.com/gotd/contrib v0.21.0 // indirect
+	github.com/hbollon/go-edlib v1.6.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
-	github.com/mattn/go-sqlite3 v1.14.22 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/jonboulle/clockwork v0.5.0 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
+	github.com/julienschmidt/httprouter v1.3.0 // indirect
+	github.com/klauspost/cpuid/v2 v2.2.10 // indirect
+	github.com/klauspost/reedsolomon v1.12.4 // indirect
+	github.com/knadh/koanf v1.5.0 // indirect
+	github.com/knadh/koanf/v2 v2.1.2 // indirect
+	github.com/mailru/easyjson v0.9.0 // indirect
+	github.com/mattn/go-sqlite3 v1.14.24 // indirect
+	github.com/minio/sha256-simd v1.0.1 // indirect
+	github.com/mitchellh/copystructure v1.2.0 // indirect
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
+	github.com/montanaflynn/stats v0.7.1 // indirect
+	github.com/mr-tron/base58 v1.2.0 // indirect
+	github.com/multiformats/go-multihash v0.2.3 // indirect
+	github.com/multiformats/go-varint v0.0.7 // indirect
+	github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 // indirect
+	github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 // indirect
+	github.com/perimeterx/marshmallow v1.1.5 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/pquerna/otp v1.4.0 // indirect
+	github.com/redis/go-redis/v9 v9.7.1 // indirect
+	github.com/robfig/cron/v3 v3.0.1 // indirect
+	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	golang.org/x/text v0.21.0 // indirect
+	github.com/urfave/cli/v3 v3.0.0-beta1 // indirect
+	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
+	go.etcd.io/etcd/api/v3 v3.5.19 // indirect
+	go.etcd.io/etcd/client/pkg/v3 v3.5.19 // indirect
+	go.etcd.io/etcd/client/v3 v3.5.19 // indirect
+	go.lumeweb.com/gswagger v0.0.0-20250525010010-2480f51b33ba // indirect
+	go.lumeweb.com/portal v0.4.2-0.20250504192002-4547d95e5a02 // indirect
+	go.lumeweb.com/portal-middleware v0.0.0-20250521113541-65cbec90e2a1 // indirect
+	go.sia.tech/core v0.10.4 // indirect
+	go.sia.tech/coreutils v0.12.1 // indirect
+	go.sia.tech/jape v0.12.1 // indirect
+	go.sia.tech/mux v1.4.0 // indirect
+	go.sia.tech/renterd v1.1.1 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/zap v1.27.0 // indirect
+	golang.org/x/crypto v0.38.0 // indirect
+	golang.org/x/net v0.40.0 // indirect
+	golang.org/x/sys v0.33.0 // indirect
+	golang.org/x/text v0.25.0 // indirect
+	golang.org/x/tools v0.33.0 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20250313205543-e70fdf4c4cb4 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20250313205543-e70fdf4c4cb4 // indirect
+	google.golang.org/grpc v1.71.0 // indirect
+	google.golang.org/protobuf v1.36.5 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gorm.io/datatypes v1.2.5 // indirect
+	gorm.io/driver/mysql v1.5.7 // indirect
+	lukechampine.com/blake3 v1.4.0 // indirect
+	lukechampine.com/frand v1.5.1 // indirect
 )
+
+replace github.com/go-viper/mapstructure/v2 => github.com/LumeWeb/mapstructure/v2 v2.0.0-20241213212524-92525f5828be

--- a/schema.go
+++ b/schema.go
@@ -1,0 +1,201 @@
+package queryutil
+
+import (
+	"reflect"
+	"strings"
+
+	"github.com/invopop/jsonschema"
+	"go.lumeweb.com/httputil"
+	"go.lumeweb.com/queryutil/filter"
+)
+
+var _ httputil.SchemaProvider = (*JsonSchamaProvider)(nil)
+
+// JsonSchamaProvider implements httputil.SchemaProvider using jsonschema reflection
+type JsonSchamaProvider struct {
+	reflector *jsonschema.Reflector
+}
+
+// NewSchemaProvider creates a new schema adapter with default configuration
+func NewSchemaProvider() *JsonSchamaProvider {
+	r := jsonschema.Reflector{
+		ExpandedStruct:             true,   // Expand nested structs
+		DoNotReference:             false,  // Allow $ref usage
+		FieldNameTag:               "json", // Use JSON tags
+		RequiredFromJSONSchemaTags: true,
+	}
+
+	return &JsonSchamaProvider{
+		reflector: &r,
+	}
+}
+
+// ForType returns a FieldSchema implementation for a given DTO type
+func (a *JsonSchamaProvider) ForType(dto any) httputil.FieldSchema {
+	t := reflect.TypeOf(dto)
+	if t == nil {
+		return &SchemaWrapper{
+			schema:  &jsonschema.Schema{},
+			dtoType: nil,
+		}
+	}
+
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	var schema *jsonschema.Schema
+	if t.Kind() == reflect.Struct {
+		schema = a.reflector.Reflect(dto)
+	} else {
+		schema = &jsonschema.Schema{}
+	}
+	return &SchemaWrapper{
+		schema:  schema,
+		dtoType: t,
+	}
+}
+
+// SchemaWrapper implements httputil.FieldSchema
+type SchemaWrapper struct {
+	schema  *jsonschema.Schema
+	dtoType reflect.Type
+}
+
+// SortableFields returns valid sort fields from the schema
+func (sw *SchemaWrapper) SortableFields() []string {
+	var fields []string
+
+	for pair := sw.schema.Properties.Oldest(); pair != nil; pair = pair.Next() {
+		fieldName := pair.Key
+		prop := pair.Value
+
+		// Skip fields without sort:"true" tag or with json:"-"
+		if tag := sw.fieldTag(fieldName, "sort"); tag != "true" {
+			continue
+		}
+
+		if isSortableType(prop) {
+			fields = append(fields, fieldName)
+		}
+	}
+
+	return fields
+}
+
+// FilterOperators returns allowed operators per field
+func (sw *SchemaWrapper) FilterOperators() map[string][]string {
+	operators := make(map[string][]string)
+
+	for pair := sw.schema.Properties.Oldest(); pair != nil; pair = pair.Next() {
+		fieldName := pair.Key
+		prop := pair.Value
+
+		// Skip fields without filter:"true" tag or with no json tag
+		if tag := sw.fieldTag(fieldName, "filter"); tag != "true" {
+			continue
+		}
+
+		ops := getOperatorsForType(prop)
+		if len(ops) > 0 {
+			operators[fieldName] = ops
+		}
+	}
+
+	return operators
+}
+
+// Helper functions
+
+func isSortableType(prop *jsonschema.Schema) bool {
+	switch {
+	case prop.Type == "string" && prop.Format != "date-time":
+		return true
+	case prop.Type == "number" || prop.Type == "integer":
+		return true
+	case prop.OneOf != nil: // Check nullable fields
+		for _, s := range prop.OneOf {
+			if isSortableType(s) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func getOperatorsForType(prop *jsonschema.Schema) []string {
+	baseType := prop.Type
+	isNullable := false
+
+	if baseType == "" && len(prop.OneOf) > 0 {
+		for _, s := range prop.OneOf {
+			if s.Type == "null" {
+				isNullable = true
+			} else if s.Type != "" {
+				baseType = s.Type
+			}
+		}
+	}
+
+	var ops []string
+	switch baseType {
+	case "string":
+		if prop.Format == "date-time" {
+			ops = []string{
+				string(filter.OpEq), string(filter.OpNe),
+				string(filter.OpGt), string(filter.OpLt),
+				string(filter.OpGte), string(filter.OpLte),
+				string(filter.OpBetween),
+			}
+		} else {
+			ops = []string{
+				string(filter.OpEq), string(filter.OpNe),
+				string(filter.OpContains), string(filter.OpStartswith),
+				string(filter.OpEndswith),
+			}
+		}
+	case "number", "integer":
+		ops = []string{
+			string(filter.OpEq), string(filter.OpNe),
+			string(filter.OpGt), string(filter.OpLt),
+			string(filter.OpGte), string(filter.OpLte),
+			string(filter.OpBetween),
+		}
+	case "boolean":
+		ops = []string{string(filter.OpEq), string(filter.OpNe)}
+	}
+
+	// Only add null checks if the field is actually nullable
+	if isNullable {
+		ops = append(ops, string(filter.OpNull), string(filter.OpNnull))
+	}
+
+	return ops
+}
+
+// fieldTag gets struct tag value for a JSON field
+func (sw *SchemaWrapper) fieldTag(jsonField, tagName string) string {
+	field := sw.findStructField(jsonField)
+	if field == nil {
+		return ""
+	}
+	return field.Tag.Get(tagName)
+}
+
+// findStructField finds the struct field by JSON tag name
+func (sw *SchemaWrapper) findStructField(jsonName string) *reflect.StructField {
+	for i := 0; i < sw.dtoType.NumField(); i++ {
+		field := sw.dtoType.Field(i)
+		tag := field.Tag.Get("json")
+		if tag == "" {
+			continue
+		}
+
+		// Handle json tag formats: "name,omitempty"
+		parts := strings.Split(tag, ",")
+		if parts[0] == jsonName {
+			return &field
+		}
+	}
+	return nil
+}

--- a/schema_test.go
+++ b/schema_test.go
@@ -1,0 +1,180 @@
+package queryutil
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/invopop/jsonschema"
+	"github.com/stretchr/testify/assert"
+	"go.lumeweb.com/queryutil/filter"
+)
+
+const (
+	stringOps = string(filter.OpEq) + "," + string(filter.OpNe) + "," +
+		string(filter.OpContains) + "," + string(filter.OpStartswith) + "," +
+		string(filter.OpEndswith)
+	numberOps = string(filter.OpEq) + "," + string(filter.OpNe) + "," +
+		string(filter.OpGt) + "," + string(filter.OpLt) + "," +
+		string(filter.OpGte) + "," + string(filter.OpLte) + "," +
+		string(filter.OpBetween)
+	boolOps = string(filter.OpEq) + "," + string(filter.OpNe)
+	dateOps = string(filter.OpEq) + "," + string(filter.OpNe) + "," +
+		string(filter.OpGt) + "," + string(filter.OpLt) + "," +
+		string(filter.OpGte) + "," + string(filter.OpLte) + "," +
+		string(filter.OpBetween)
+	nullableOps = string(filter.OpNull) + "," + string(filter.OpNnull)
+)
+
+func stringOperators() []string {
+	return strings.Split(stringOps, ",")
+}
+
+func numberOperators() []string {
+	return strings.Split(numberOps, ",")
+}
+
+func boolOperators() []string {
+	return strings.Split(boolOps, ",")
+}
+
+func dateOperators() []string {
+	return strings.Split(dateOps, ",")
+}
+
+type TestDTO struct {
+	ID          int       `json:"id" sort:"true" filter:"true"`
+	Name        string    `json:"name" sort:"true"`
+	Email       string    `json:"email" filter:"true"`
+	CreatedAt   time.Time `json:"created_at" sort:"true" filter:"true"`
+	IsActive    bool      `json:"is_active" filter:"true"`
+	Rating      float64   `json:"rating" sort:"false" filter:"true"`
+	NullField   *string   `json:"null_field" filter:"true"`
+	NoTagField  string
+	HiddenField string `json:"-" sort:"true"`
+}
+
+func TestNewSchemaProvider(t *testing.T) {
+	provider := NewSchemaProvider()
+	assert.NotNil(t, provider)
+	assert.NotNil(t, provider.reflector)
+}
+
+func TestForType(t *testing.T) {
+	provider := NewSchemaProvider()
+	schema := provider.ForType(TestDTO{})
+	assert.NotNil(t, schema)
+
+	// Test with pointer type
+	schemaPtr := provider.ForType(&TestDTO{})
+	assert.NotNil(t, schemaPtr)
+}
+
+func TestSortableFields(t *testing.T) {
+	provider := NewSchemaProvider()
+	schema := provider.ForType(TestDTO{})
+
+	fields := schema.SortableFields()
+	expected := []string{"id", "name"}
+	assert.ElementsMatch(t, expected, fields)
+
+	// Verify excluded fields
+	assert.NotContains(t, fields, "email")       // no sort tag
+	assert.NotContains(t, fields, "rating")      // sort:"false"
+	assert.NotContains(t, fields, "NoTagField")  // no json tag
+	assert.NotContains(t, fields, "HiddenField") // json:"-"
+}
+
+func TestFilterOperators(t *testing.T) {
+	provider := NewSchemaProvider()
+	schema := provider.ForType(TestDTO{})
+
+	operators := schema.FilterOperators()
+	assert.NotEmpty(t, operators)
+
+	// Test specific field operators
+	assert.ElementsMatch(t, boolOperators(), operators["is_active"])
+	assert.ElementsMatch(t, dateOperators(), operators["created_at"])
+	assert.ElementsMatch(t, stringOperators(), operators["email"])
+
+	// email is non-nullable string - should have base string operators
+	assert.ElementsMatch(t, stringOperators(), operators["email"])
+
+	// null_field is nullable string - should have base string operators
+	assert.ElementsMatch(t, stringOperators(), operators["null_field"])
+
+	// Verify excluded fields
+	assert.NotContains(t, operators, "name")        // no filter tag
+	assert.NotContains(t, operators, "NoTagField")  // no json tag
+	assert.NotContains(t, operators, "HiddenField") // json:"-"
+}
+
+func TestFieldTagHelpers(t *testing.T) {
+	provider := NewSchemaProvider()
+	schema := provider.ForType(TestDTO{}).(*SchemaWrapper)
+
+	// Test field tag lookup
+	assert.Equal(t, "true", schema.fieldTag("id", "sort"))
+	assert.Equal(t, "true", schema.fieldTag("email", "filter"))
+	assert.Equal(t, "", schema.fieldTag("nonexistent", "sort"))
+
+	// Test struct field finding
+	field := schema.findStructField("name")
+	assert.NotNil(t, field)
+	assert.Equal(t, "Name", field.Name)
+
+	field = schema.findStructField("invalid")
+	assert.Nil(t, field)
+}
+
+func TestTypeHelpers(t *testing.T) {
+	// Test isSortableType
+	assert.True(t, isSortableType(&jsonschema.Schema{Type: "string"}))
+	assert.True(t, isSortableType(&jsonschema.Schema{Type: "number"}))
+	assert.False(t, isSortableType(&jsonschema.Schema{Type: "boolean"}))
+	assert.False(t, isSortableType(&jsonschema.Schema{Type: "string", Format: "date-time"}))
+
+	// Nullable field check
+	assert.True(t, isSortableType(&jsonschema.Schema{
+		OneOf: []*jsonschema.Schema{
+			{Type: "string"},
+			{Type: "null"},
+		},
+	}))
+
+	// Test getOperatorsForType
+	assert.ElementsMatch(t, stringOperators(),
+		getOperatorsForType(&jsonschema.Schema{Type: "string"}))
+	assert.ElementsMatch(t, numberOperators(),
+		getOperatorsForType(&jsonschema.Schema{Type: "number"}))
+	assert.ElementsMatch(t, boolOperators(),
+		getOperatorsForType(&jsonschema.Schema{Type: "boolean"}))
+	assert.ElementsMatch(t, dateOperators(),
+		getOperatorsForType(&jsonschema.Schema{Type: "string", Format: "date-time"}))
+
+	// Test nullable field
+	nullableSchema := &jsonschema.Schema{
+		OneOf: []*jsonschema.Schema{
+			{Type: "string"},
+			{Type: "null"},
+		},
+	}
+	expectedNullableOps := append(stringOperators(), strings.Split(nullableOps, ",")...)
+	assert.ElementsMatch(t, expectedNullableOps, getOperatorsForType(nullableSchema))
+}
+
+func TestEdgeCases(t *testing.T) {
+	// Test empty struct
+	type Empty struct{}
+	provider := NewSchemaProvider()
+	schema := provider.ForType(Empty{})
+
+	assert.Empty(t, schema.SortableFields())
+	assert.Empty(t, schema.FilterOperators())
+
+	// Test non-struct type
+	assert.NotPanics(t, func() {
+		schema := provider.ForType("string")
+		assert.NotNil(t, schema)
+	})
+}


### PR DESCRIPTION
- Added new JsonSchamaProvider implementing httputil.SchemaProvider
- Added schema wrapper with SortableFields() and FilterOperators() methods
- Added comprehensive tests for schema functionality
- Updated go.mod with new dependencies (jsonschema, httputil)