### PR TITLE
refactor: update dependencies and rename httputil to portal-router

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,118 +8,49 @@ require (
 	github.com/invopop/jsonschema v0.13.0
 	github.com/samber/lo v1.49.1
 	github.com/stretchr/testify v1.10.0
-	go.lumeweb.com/httputil v0.5.0
+	go.lumeweb.com/portal-router v0.2.3
 	golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6
 	gorm.io/driver/sqlite v1.5.7
 	gorm.io/gorm v1.25.12
 )
 
 require (
-	filippo.io/edwards25519 v1.1.0 // indirect
-	github.com/AfterShip/email-verifier v1.4.1 // indirect
-	github.com/Oudwins/zog v0.18.4 // indirect
-	github.com/aws/aws-sdk-go-v2 v1.36.3 // indirect
-	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.10 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.34 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.34 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.34 // indirect
-	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.3 // indirect
-	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.7.0 // indirect
-	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.15 // indirect
-	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.15 // indirect
-	github.com/aws/aws-sdk-go-v2/service/s3 v1.78.2 // indirect
-	github.com/aws/smithy-go v1.22.3 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
-	github.com/boombuler/barcode v1.0.2 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
-	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/coreos/go-semver v0.3.1 // indirect
-	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
-	github.com/docker/go-units v0.5.0 // indirect
-	github.com/fsnotify/fsnotify v1.8.0 // indirect
-	github.com/gammazero/deque v1.0.0 // indirect
-	github.com/gammazero/workerpool v1.1.3 // indirect
 	github.com/getkin/kin-openapi v0.132.0 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
-	github.com/go-co-op/gocron/v2 v2.16.1 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
-	github.com/go-sql-driver/mysql v1.9.0 // indirect
-	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
-	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
-	github.com/golang/protobuf v1.5.4 // indirect
-	github.com/google/uuid v1.6.0 // indirect
-	github.com/gookit/event v1.1.2 // indirect
-	github.com/gorilla/mux v1.8.2-0.20240619235004-db9d1d0073d2 // indirect
-	github.com/gotd/contrib v0.21.0 // indirect
-	github.com/hbollon/go-edlib v1.6.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
-	github.com/jonboulle/clockwork v0.5.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
-	github.com/julienschmidt/httprouter v1.3.0 // indirect
-	github.com/klauspost/cpuid/v2 v2.2.10 // indirect
-	github.com/klauspost/reedsolomon v1.12.4 // indirect
-	github.com/knadh/koanf v1.5.0 // indirect
-	github.com/knadh/koanf/v2 v2.1.2 // indirect
 	github.com/labstack/echo/v4 v4.13.4 // indirect
 	github.com/labstack/gommon v0.4.2 // indirect
 	github.com/mailru/easyjson v0.9.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-sqlite3 v1.14.24 // indirect
-	github.com/minio/sha256-simd v1.0.1 // indirect
-	github.com/mitchellh/copystructure v1.2.0 // indirect
-	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
-	github.com/montanaflynn/stats v0.7.1 // indirect
-	github.com/mr-tron/base58 v1.2.0 // indirect
-	github.com/multiformats/go-multihash v0.2.3 // indirect
-	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 // indirect
 	github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/pquerna/otp v1.4.0 // indirect
-	github.com/redis/go-redis/v9 v9.7.1 // indirect
-	github.com/robfig/cron/v3 v3.0.1 // indirect
-	github.com/spaolacci/murmur3 v1.1.0 // indirect
+	github.com/rogpeppe/go-internal v1.13.1 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	github.com/urfave/cli/v3 v3.0.0-beta1 // indirect
+	github.com/ugorji/go/codec v1.2.12 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
-	go.etcd.io/etcd/api/v3 v3.5.19 // indirect
-	go.etcd.io/etcd/client/pkg/v3 v3.5.19 // indirect
-	go.etcd.io/etcd/client/v3 v3.5.19 // indirect
 	go.lumeweb.com/gswagger v0.16.1 // indirect
-	go.lumeweb.com/portal v0.4.2-0.20250504192002-4547d95e5a02 // indirect
-	go.lumeweb.com/portal-middleware v0.0.0-20250521113541-65cbec90e2a1 // indirect
-	go.sia.tech/core v0.10.4 // indirect
-	go.sia.tech/coreutils v0.12.1 // indirect
-	go.sia.tech/jape v0.12.1 // indirect
-	go.sia.tech/mux v1.4.0 // indirect
-	go.sia.tech/renterd v1.1.1 // indirect
-	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.27.0 // indirect
+	go.lumeweb.com/portal-middleware v0.2.5 // indirect
 	golang.org/x/crypto v0.38.0 // indirect
 	golang.org/x/net v0.40.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.25.0 // indirect
-	golang.org/x/tools v0.33.0 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20250313205543-e70fdf4c4cb4 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20250313205543-e70fdf4c4cb4 // indirect
-	google.golang.org/grpc v1.71.0 // indirect
-	google.golang.org/protobuf v1.36.5 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	gorm.io/datatypes v1.2.5 // indirect
-	gorm.io/driver/mysql v1.5.7 // indirect
-	lukechampine.com/blake3 v1.4.0 // indirect
-	lukechampine.com/frand v1.5.1 // indirect
 )
 
 replace github.com/go-viper/mapstructure/v2 => github.com/LumeWeb/mapstructure/v2 v2.0.0-20241213212524-92525f5828be

--- a/schema.go
+++ b/schema.go
@@ -5,11 +5,11 @@ import (
 	"strings"
 
 	"github.com/invopop/jsonschema"
-	"go.lumeweb.com/httputil"
+	"go.lumeweb.com/portal-router"
 	"go.lumeweb.com/queryutil/filter"
 )
 
-var _ httputil.SchemaProvider = (*JsonSchamaProvider)(nil)
+var _ router.SchemaProvider = (*JsonSchamaProvider)(nil)
 
 // JsonSchamaProvider implements httputil.SchemaProvider using jsonschema reflection
 type JsonSchamaProvider struct {
@@ -31,7 +31,7 @@ func NewSchemaProvider() *JsonSchamaProvider {
 }
 
 // ForType returns a FieldSchema implementation for a given DTO type
-func (a *JsonSchamaProvider) ForType(dto any) httputil.FieldSchema {
+func (a *JsonSchamaProvider) ForType(dto any) router.FieldSchema {
 	t := reflect.TypeOf(dto)
 	if t == nil {
 		return &SchemaWrapper{


### PR DESCRIPTION
- Updated go.mod to remove unused dependencies and switch from httputil to portal-router
- Changed schema.go to use portal-router.SchemaProvider interface instead of httputil.SchemaProvider
- Simplified indirect dependencies in go.mod