### PR TITLE
feat: make Response type generic

### DIFF
--- a/http/handlers.go
+++ b/http/handlers.go
@@ -110,6 +110,6 @@ func ProcessListRequest[T any, D any](
 	SetContentRangeHeader(w, entityName, pagination, responses, total)
 
 	// Encode response using our enhanced JSON encoder
-	response := queryutil.BuildResponse(responses, total)
+	response := queryutil.BuildResponse[T](responses, total)
 	return EncodeJSON(w, response)
 }

--- a/response.go
+++ b/response.go
@@ -3,8 +3,8 @@ package queryutil
 // Response represents a standard response structure for list operations.
 // It includes both the data payload and a total count for pagination.
 // This structure is compatible with Refine's Simple REST Data Provider.
-type Response struct {
-	Data  any   `json:"data"`
+type Response[T any] struct {
+	Data  T     `json:"data"`
 	Total int64 `json:"total"`
 }
 
@@ -18,8 +18,8 @@ type Response struct {
 //	totalCount := int64(100)
 //	response := BuildResponse(users, totalCount)
 //	// response can be encoded to JSON and sent to the client
-func BuildResponse(data any, total int64) *Response {
-	return &Response{
+func BuildResponse[T any](data T, total int64) *Response[T] {
+	return &Response[T]{
 		Data:  data,
 		Total: total,
 	}

--- a/response_test.go
+++ b/response_test.go
@@ -1,8 +1,8 @@
 package queryutil
 
 import (
-	"testing"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestBuildResponse(t *testing.T) {


### PR DESCRIPTION
- Convert Response struct to use generics (Response[T]) for type safety
- Update BuildResponse function to match new generic type
- Modify handler to use generic response builder