### PR TITLE
feat: add filter search utilities

### DIFF
--- a/find.go
+++ b/find.go
@@ -1,0 +1,61 @@
+package queryutil
+
+import (
+	"github.com/samber/lo"
+	"go.lumeweb.com/queryutil/filter"
+)
+
+// FindFilter extracts the first CrudFilter with a matching field from a slice of filters.
+// It performs a shallow search, only examining the top-level filters.
+// Returns nil if no matching filter is found.
+func FindFilter(filters []filter.CrudFilter, field string) filter.CrudFilter {
+	return lo.FindOrElse(filters, nil, func(f filter.CrudFilter) bool {
+		return f.GetField() == field
+	})
+}
+
+// FindFilters extracts all CrudFilters with a matching field from a slice of filters.
+// It performs a shallow search, only examining the top-level filters.
+// Returns an empty slice if no matching filters are found.
+func FindFilters(filters []filter.CrudFilter, field string) []filter.CrudFilter {
+	return lo.Filter(filters, func(f filter.CrudFilter, _ int) bool {
+		return f.GetField() == field
+	})
+}
+
+// DeepFindFilter recursively searches for the first CrudFilter with a matching field.
+// It traverses ConditionalFilters (AND, OR, NOT) to find nested filters.
+// Returns nil if no matching filter is found.
+func DeepFindFilter(filters []filter.CrudFilter, field string) filter.CrudFilter {
+	for _, f := range filters {
+		if f.GetField() == field {
+			return f
+		}
+
+		if cf, ok := f.(*filter.ConditionalFilter); ok {
+			if found := DeepFindFilter(cf.GetFilters(), field); found != nil {
+				return found
+			}
+		}
+	}
+	return nil
+}
+
+// DeepFindFilters recursively searches for all CrudFilters with a matching field.
+// It traverses ConditionalFilters (AND, OR, NOT) to find nested filters.
+// Returns an empty slice if no matching filters are found.
+func DeepFindFilters(filters []filter.CrudFilter, field string) []filter.CrudFilter {
+	var results []filter.CrudFilter
+
+	for _, f := range filters {
+		if f.GetField() == field {
+			results = append(results, f)
+		}
+
+		if cf, ok := f.(*filter.ConditionalFilter); ok {
+			results = append(results, DeepFindFilters(cf.GetFilters(), field)...)
+		}
+	}
+
+	return results
+}

--- a/find_test.go
+++ b/find_test.go
@@ -1,0 +1,125 @@
+package queryutil
+
+import (
+	"go.lumeweb.com/queryutil/filter"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindFilter(t *testing.T) {
+	filters := []filter.CrudFilter{
+		filter.NewLogicalFilter("status", filter.OpEq, "active"),
+		filter.NewConditionalFilter(filter.LogicalAnd, []filter.CrudFilter{
+			filter.NewLogicalFilter("age", filter.OpGte, 18),
+			filter.NewLogicalFilter("country", filter.OpEq, "USA"),
+		}),
+		filter.NewLogicalFilter("name", filter.OpContains, "john"),
+	}
+
+	// Test cases for FindFilter
+	t.Run("shallow find - existing field", func(t *testing.T) {
+		result := FindFilter(filters, "name")
+		assert.NotNil(t, result)
+		assert.Equal(t, "name", result.GetField())
+	})
+
+	t.Run("shallow find - non-existing field", func(t *testing.T) {
+		result := FindFilter(filters, "city")
+		assert.Nil(t, result)
+	})
+
+	// Test cases for FindFilters
+	t.Run("shallow finds - existing field", func(t *testing.T) {
+		results := FindFilters(filters, "status")
+		assert.NotEmpty(t, results)
+		assert.Len(t, results, 1)
+		assert.Equal(t, "status", results[0].GetField())
+	})
+
+	t.Run("shallow finds - non-existing field", func(t *testing.T) {
+		results := FindFilters(filters, "city")
+		assert.Empty(t, results)
+	})
+
+	// Test cases for DeepFindFilter
+	t.Run("deep find - existing field", func(t *testing.T) {
+		result := DeepFindFilter(filters, "age")
+		assert.NotNil(t, result)
+		assert.Equal(t, "age", result.GetField())
+	})
+
+	t.Run("deep find - non-existing field", func(t *testing.T) {
+		result := DeepFindFilter(filters, "city")
+		assert.Nil(t, result)
+	})
+
+	// Test cases for DeepFindFilters
+	t.Run("deep finds - existing field", func(t *testing.T) {
+		results := DeepFindFilters(filters, "country")
+		assert.NotEmpty(t, results)
+		assert.Len(t, results, 1)
+		assert.Equal(t, "country", results[0].GetField())
+	})
+
+	t.Run("deep finds - non-existing field", func(t *testing.T) {
+		results := DeepFindFilters(filters, "city")
+		assert.Empty(t, results)
+	})
+
+	t.Run("deep finds - multiple matches", func(t *testing.T) {
+		// Add another nested filter with the same field
+		filters[1].(*filter.ConditionalFilter).Filters = append(filters[1].(*filter.ConditionalFilter).Filters, filter.NewLogicalFilter("age", filter.OpLt, 30))
+		results := DeepFindFilters(filters, "age")
+		assert.NotEmpty(t, results)
+		assert.Len(t, results, 2)
+		assert.Equal(t, "age", results[0].GetField())
+		assert.Equal(t, "age", results[1].GetField())
+	})
+
+	t.Run("deep find - or conditional", func(t *testing.T) {
+		filters := []filter.CrudFilter{
+			filter.NewConditionalFilter(filter.LogicalOr, []filter.CrudFilter{
+				filter.NewLogicalFilter("age", filter.OpGte, 18),
+				filter.NewLogicalFilter("country", filter.OpEq, "USA"),
+			}),
+		}
+
+		result := DeepFindFilter(filters, "age")
+		assert.NotNil(t, result)
+		assert.Equal(t, "age", result.GetField())
+
+		result = DeepFindFilter(filters, "country")
+		assert.NotNil(t, result)
+		assert.Equal(t, "country", result.GetField())
+	})
+
+	t.Run("deep find - and conditional", func(t *testing.T) {
+		filters := []filter.CrudFilter{
+			filter.NewConditionalFilter(filter.LogicalAnd, []filter.CrudFilter{
+				filter.NewLogicalFilter("age", filter.OpGte, 18),
+				filter.NewLogicalFilter("country", filter.OpEq, "USA"),
+			}),
+		}
+
+		result := DeepFindFilter(filters, "age")
+		assert.NotNil(t, result)
+		assert.Equal(t, "age", result.GetField())
+
+		result = DeepFindFilter(filters, "country")
+		assert.NotNil(t, result)
+		assert.Equal(t, "country", result.GetField())
+	})
+
+	t.Run("deep find - not conditional", func(t *testing.T) {
+		filters := []filter.CrudFilter{
+			filter.NewConditionalFilter(filter.LogicalNot, []filter.CrudFilter{
+				filter.NewLogicalFilter("age", filter.OpGte, 18),
+			}),
+		}
+
+		result := DeepFindFilter(filters, "age")
+		assert.NotNil(t, result)
+		assert.Equal(t, "age", result.GetField())
+	})
+}


### PR DESCRIPTION
Add four new utility functions for finding filters:
- FindFilter: shallow search for first matching filter
- FindFilters: shallow search for all matching filters
- DeepFindFilter: recursive search for first matching filter
- DeepFindFilters: recursive search for all matching filters

Includes comprehensive test coverage for all functions.