### PR TITLE
feat: add operator-aware filter finding functions

### DIFF
--- a/find.go
+++ b/find.go
@@ -9,8 +9,21 @@ import (
 // It performs a shallow search, only examining the top-level filters.
 // Returns nil if no matching filter is found.
 func FindFilter(filters []filter.CrudFilter, field string) filter.CrudFilter {
+	return FindFilterWithOperator(filters, field, "")
+}
+
+// FindFilterWithOperator extracts the first CrudFilter with matching field and operator from a slice of filters.
+// It performs a shallow search, only examining the top-level filters.
+// Returns nil if no matching filter is found.
+func FindFilterWithOperator(filters []filter.CrudFilter, field string, operator filter.Operator) filter.CrudFilter {
 	return lo.FindOrElse(filters, nil, func(f filter.CrudFilter) bool {
-		return f.GetField() == field
+		if f.GetField() != field {
+			return false
+		}
+		if operator != "" {
+			return f.GetOperator() == operator
+		}
+		return true
 	})
 }
 
@@ -18,8 +31,21 @@ func FindFilter(filters []filter.CrudFilter, field string) filter.CrudFilter {
 // It performs a shallow search, only examining the top-level filters.
 // Returns an empty slice if no matching filters are found.
 func FindFilters(filters []filter.CrudFilter, field string) []filter.CrudFilter {
+	return FindFiltersWithOperator(filters, field, "")
+}
+
+// FindFiltersWithOperator extracts all CrudFilters with matching field and operator from a slice of filters.
+// It performs a shallow search, only examining the top-level filters.
+// Returns an empty slice if no matching filters are found.
+func FindFiltersWithOperator(filters []filter.CrudFilter, field string, operator filter.Operator) []filter.CrudFilter {
 	return lo.Filter(filters, func(f filter.CrudFilter, _ int) bool {
-		return f.GetField() == field
+		if f.GetField() != field {
+			return false
+		}
+		if operator != "" {
+			return f.GetOperator() == operator
+		}
+		return true
 	})
 }
 
@@ -27,13 +53,20 @@ func FindFilters(filters []filter.CrudFilter, field string) []filter.CrudFilter 
 // It traverses ConditionalFilters (AND, OR, NOT) to find nested filters.
 // Returns nil if no matching filter is found.
 func DeepFindFilter(filters []filter.CrudFilter, field string) filter.CrudFilter {
+	return DeepFindFilterWithOperator(filters, field, "")
+}
+
+// DeepFindFilterWithOperator recursively searches for the first CrudFilter with matching field and operator.
+// It traverses ConditionalFilters (AND, OR, NOT) to find nested filters.
+// Returns nil if no matching filter is found.
+func DeepFindFilterWithOperator(filters []filter.CrudFilter, field string, operator filter.Operator) filter.CrudFilter {
 	for _, f := range filters {
-		if f.GetField() == field {
+		if f.GetField() == field && (operator == "" || f.GetOperator() == operator) {
 			return f
 		}
 
 		if cf, ok := f.(*filter.ConditionalFilter); ok {
-			if found := DeepFindFilter(cf.GetFilters(), field); found != nil {
+			if found := DeepFindFilterWithOperator(cf.GetFilters(), field, operator); found != nil {
 				return found
 			}
 		}
@@ -45,15 +78,22 @@ func DeepFindFilter(filters []filter.CrudFilter, field string) filter.CrudFilter
 // It traverses ConditionalFilters (AND, OR, NOT) to find nested filters.
 // Returns an empty slice if no matching filters are found.
 func DeepFindFilters(filters []filter.CrudFilter, field string) []filter.CrudFilter {
+	return DeepFindFiltersWithOperator(filters, field, "")
+}
+
+// DeepFindFiltersWithOperator recursively searches for all CrudFilters with matching field and operator.
+// It traverses ConditionalFilters (AND, OR, NOT) to find nested filters.
+// Returns an empty slice if no matching filters are found.
+func DeepFindFiltersWithOperator(filters []filter.CrudFilter, field string, operator filter.Operator) []filter.CrudFilter {
 	var results []filter.CrudFilter
 
 	for _, f := range filters {
-		if f.GetField() == field {
+		if f.GetField() == field && (operator == "" || f.GetOperator() == operator) {
 			results = append(results, f)
 		}
 
 		if cf, ok := f.(*filter.ConditionalFilter); ok {
-			results = append(results, DeepFindFilters(cf.GetFilters(), field)...)
+			results = append(results, DeepFindFiltersWithOperator(cf.GetFilters(), field, operator)...)
 		}
 	}
 

--- a/find_test.go
+++ b/find_test.go
@@ -29,6 +29,23 @@ func TestFindFilter(t *testing.T) {
 		assert.Nil(t, result)
 	})
 
+	t.Run("shallow find with operator - existing", func(t *testing.T) {
+		result := FindFilterWithOperator(filters, "status", filter.OpEq)
+		assert.NotNil(t, result)
+		assert.Equal(t, "status", result.GetField())
+		assert.Equal(t, filter.OpEq, result.GetOperator())
+	})
+
+	t.Run("shallow find with operator - non-existing operator", func(t *testing.T) {
+		result := FindFilterWithOperator(filters, "status", filter.OpGt)
+		assert.Nil(t, result)
+	})
+
+	t.Run("shallow find with operator - non-existing field", func(t *testing.T) {
+		result := FindFilterWithOperator(filters, "city", filter.OpEq)
+		assert.Nil(t, result)
+	})
+
 	// Test cases for FindFilters
 	t.Run("shallow finds - existing field", func(t *testing.T) {
 		results := FindFilters(filters, "status")
@@ -39,6 +56,24 @@ func TestFindFilter(t *testing.T) {
 
 	t.Run("shallow finds - non-existing field", func(t *testing.T) {
 		results := FindFilters(filters, "city")
+		assert.Empty(t, results)
+	})
+
+	t.Run("shallow finds with operator - existing", func(t *testing.T) {
+		results := FindFiltersWithOperator(filters, "status", filter.OpEq)
+		assert.NotEmpty(t, results)
+		assert.Len(t, results, 1)
+		assert.Equal(t, "status", results[0].GetField())
+		assert.Equal(t, filter.OpEq, results[0].GetOperator())
+	})
+
+	t.Run("shallow finds with operator - non-existing operator", func(t *testing.T) {
+		results := FindFiltersWithOperator(filters, "status", filter.OpGt)
+		assert.Empty(t, results)
+	})
+
+	t.Run("shallow finds with operator - non-existing field", func(t *testing.T) {
+		results := FindFiltersWithOperator(filters, "city", filter.OpEq)
 		assert.Empty(t, results)
 	})
 
@@ -54,6 +89,23 @@ func TestFindFilter(t *testing.T) {
 		assert.Nil(t, result)
 	})
 
+	t.Run("deep find with operator - existing", func(t *testing.T) {
+		result := DeepFindFilterWithOperator(filters, "age", filter.OpGte)
+		assert.NotNil(t, result)
+		assert.Equal(t, "age", result.GetField())
+		assert.Equal(t, filter.OpGte, result.GetOperator())
+	})
+
+	t.Run("deep find with operator - non-existing operator", func(t *testing.T) {
+		result := DeepFindFilterWithOperator(filters, "age", filter.OpLt)
+		assert.Nil(t, result)
+	})
+
+	t.Run("deep find with operator - non-existing field", func(t *testing.T) {
+		result := DeepFindFilterWithOperator(filters, "city", filter.OpEq)
+		assert.Nil(t, result)
+	})
+
 	// Test cases for DeepFindFilters
 	t.Run("deep finds - existing field", func(t *testing.T) {
 		results := DeepFindFilters(filters, "country")
@@ -64,6 +116,24 @@ func TestFindFilter(t *testing.T) {
 
 	t.Run("deep finds - non-existing field", func(t *testing.T) {
 		results := DeepFindFilters(filters, "city")
+		assert.Empty(t, results)
+	})
+
+	t.Run("deep finds with operator - existing", func(t *testing.T) {
+		results := DeepFindFiltersWithOperator(filters, "age", filter.OpGte)
+		assert.NotEmpty(t, results)
+		assert.Len(t, results, 1)
+		assert.Equal(t, "age", results[0].GetField())
+		assert.Equal(t, filter.OpGte, results[0].GetOperator())
+	})
+
+	t.Run("deep finds with operator - non-existing operator", func(t *testing.T) {
+		results := DeepFindFiltersWithOperator(filters, "age", filter.OpLt)
+		assert.Empty(t, results)
+	})
+
+	t.Run("deep finds with operator - non-existing field", func(t *testing.T) {
+		results := DeepFindFiltersWithOperator(filters, "city", filter.OpEq)
 		assert.Empty(t, results)
 	})
 


### PR DESCRIPTION
- Added new variants of filter finding functions that can match both field name and operator:
  - FindFilterWithOperator
  - FindFiltersWithOperator
  - DeepFindFilterWithOperator
  - DeepFindFiltersWithOperator
- Modified existing functions to use the new operator-aware versions internally
- Added comprehensive tests for all new functionality
- Maintained backward compatibility with existing function signatures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced filter search functionality to allow searching by both field and operator, providing more precise results.
- **Tests**
  - Added new test cases to verify correct behavior when searching filters by both field and operator, ensuring reliability and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->