### PR TITLE
feat: implement query parameter generator and improve operator mapping

### DIFF
--- a/filter/core.go
+++ b/filter/core.go
@@ -3,9 +3,10 @@ package filter
 import (
 	"errors"
 	"fmt"
-	"strings"
-
 	"github.com/samber/lo"
+	"sort"
+	"strings"
+	"sync"
 )
 
 // Operator defines comparison operations for field values (eq, gt, contains, etc)
@@ -49,6 +50,41 @@ const (
 	WhereClauseType    ClauseType = iota // Direct field comparison clause
 	CompoundClauseType                   // Group of clauses combined with AND/OR/NOT
 )
+
+// operatorReverseMap provides reverse lookup from Operator to all its string representations
+var operatorReverseMap map[Operator][]string
+var operatorMapMutex sync.RWMutex
+
+// GetOperatorReverseMap returns a copy of the operator reverse map
+func GetOperatorReverseMap() map[Operator][]string {
+	operatorMapMutex.RLock()
+	defer operatorMapMutex.RUnlock()
+
+	return lo.MapValues(operatorReverseMap, func(v []string, _ Operator) []string {
+		return append([]string{}, v...)
+	})
+}
+
+func init() {
+	operatorMapMutex.Lock()
+	defer operatorMapMutex.Unlock()
+
+	// Sort the keys of OperatorMap to ensure deterministic inversion
+	keys := make([]string, 0, len(OperatorMap))
+	for k := range OperatorMap {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	// Create a temporary map for inversion that collects all aliases
+	tempMap := make(map[Operator][]string, len(OperatorMap))
+	for _, k := range keys {
+		op := OperatorMap[k]
+		tempMap[op] = append(tempMap[op], k)
+	}
+
+	operatorReverseMap = tempMap
+}
 
 // LogicalFilter represents a direct field comparison condition
 type LogicalFilter struct {
@@ -216,11 +252,8 @@ var OperatorMap = map[string]Operator{
 	"like":         OpContains, // Alias for contains
 }
 
-// OperatorReverseMap provides reverse lookup from Operator to its string representation
-var OperatorReverseMap = lo.Invert(OperatorMap)
-
 func (o Operator) String() string {
-    return string(o)
+	return string(o)
 }
 
 const (

--- a/filter/generator/generator.go
+++ b/filter/generator/generator.go
@@ -1,0 +1,154 @@
+package generator
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+
+	"github.com/samber/lo"
+	"go.lumeweb.com/queryutil/filter"
+)
+
+// QueryParamGenerator converts CrudFilters into URL query parameters
+type QueryParamGenerator interface {
+	Generate(filters []filter.CrudFilter) (map[string][]string, error)
+}
+
+// DefaultQueryParamGenerator is the standard implementation of QueryParamGenerator
+type DefaultQueryParamGenerator struct{}
+
+// NewDefaultQueryParamGenerator creates a new DefaultQueryParamGenerator
+func NewDefaultQueryParamGenerator() QueryParamGenerator {
+	return &DefaultQueryParamGenerator{}
+}
+
+// Generate converts filters into URL query parameters
+func (g *DefaultQueryParamGenerator) Generate(filters []filter.CrudFilter) (map[string][]string, error) {
+	query := make(map[string][]string)
+	generator := &queryGenerator{
+		query: query,
+	}
+
+	if err := generator.processFilters(filters, []string{"filters"}); err != nil {
+		return nil, err
+	}
+	return query, nil
+}
+
+// queryGenerator holds state for generating query parameters
+type queryGenerator struct {
+	query map[string][]string
+}
+
+// processFilters recursively processes filters into query parameters
+func (g *queryGenerator) processFilters(filters []filter.CrudFilter, path []string) error {
+	for i, f := range filters {
+		switch v := f.(type) {
+		case *filter.LogicalFilter:
+			if err := g.processLogicalFilter(v, path); err != nil {
+				return err
+			}
+		case *filter.ConditionalFilter:
+			if err := g.processConditionalFilter(v, path, i); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unsupported filter type: %T", f)
+		}
+	}
+	return nil
+}
+
+// processLogicalFilter handles a single logical filter
+func (g *queryGenerator) processLogicalFilter(f *filter.LogicalFilter, path []string) error {
+	// Handle global search (q) specially
+	if f.Field() == "q" {
+		g.query["q"] = []string{url.QueryEscape(fmt.Sprint(f.Value()))}
+		return nil
+	}
+
+	// Build path segments
+	segments := append(path, f.Field())
+	if f.Operator() != filter.OpEq {
+		opStrs, ok := filter.GetOperatorReverseMap()[f.Operator()]
+		if !ok {
+			return fmt.Errorf("unsupported operator: %s", f.Operator())
+		}
+		// Use the first alias (primary operator name) from the reverse map
+		segments = append(segments, opStrs[0])
+	}
+
+	key := buildQueryKey(segments)
+
+	// Handle values
+	values, err := g.getFilterValues(f)
+	if err != nil {
+		return err
+	}
+
+	g.query[key] = values
+	return nil
+}
+
+// processConditionalFilter handles AND/OR/NOT conditional filters
+func (g *queryGenerator) processConditionalFilter(f *filter.ConditionalFilter, path []string, index int) error {
+	// For conditional filters, we need to maintain the original index structure
+	// from the test expectations
+	newPath := append(path, string(f.Operator))
+	for i, subFilter := range f.Filters {
+		subPath := append(newPath, strconv.Itoa(i))
+		switch sf := subFilter.(type) {
+		case *filter.LogicalFilter:
+			if err := g.processLogicalFilter(sf, subPath); err != nil {
+				return err
+			}
+		case *filter.ConditionalFilter:
+			if err := g.processConditionalFilter(sf, subPath, i); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unsupported filter type: %T", subFilter)
+		}
+	}
+	return nil
+}
+
+// getFilterValues converts filter values to URL-encoded strings
+func (g *queryGenerator) getFilterValues(f *filter.LogicalFilter) ([]string, error) {
+	switch val := f.Value().(type) {
+	case []any: // For "in" and "between"
+		if f.Operator() == filter.OpBetween || f.Operator() == filter.OpNbetween {
+			if len(val) != 2 {
+				return nil, fmt.Errorf("between operator requires exactly 2 values")
+			}
+			// Validate between values are numeric before encoding
+			if _, err := strconv.ParseFloat(fmt.Sprint(val[0]), 64); err != nil {
+				return nil, fmt.Errorf("between operator requires numeric values")
+			}
+			if _, err := strconv.ParseFloat(fmt.Sprint(val[1]), 64); err != nil {
+				return nil, fmt.Errorf("between operator requires numeric values")
+			}
+		}
+		values := lo.Map(val, func(item any, _ int) string {
+			return url.QueryEscape(fmt.Sprint(item))
+		})
+		return values, nil
+	case nil: // For null/nnull operators
+		return []string{""}, nil
+	default:
+		return []string{url.QueryEscape(fmt.Sprint(f.Value()))}, nil
+	}
+}
+
+// buildQueryKey constructs a query parameter key from path segments
+func buildQueryKey(segments []string) string {
+	if len(segments) == 0 {
+		return ""
+	}
+
+	key := segments[0]
+	for _, seg := range segments[1:] {
+		key += "[" + seg + "]"
+	}
+	return key
+}

--- a/filter/generator/generator_test.go
+++ b/filter/generator/generator_test.go
@@ -1,0 +1,191 @@
+package generator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.lumeweb.com/queryutil/filter"
+)
+
+func TestDefaultQueryParamGenerator_Generate(t *testing.T) {
+	tests := []struct {
+		name     string
+		filters  func() []filter.CrudFilter
+		expected map[string][]string
+		wantErr  bool
+	}{
+		{
+			name: "basic equality",
+			filters: func() []filter.CrudFilter {
+				return []filter.CrudFilter{
+					filter.NewLogicalFilter("name", filter.OpEq, "john"),
+				}
+			},
+			expected: map[string][]string{
+				"filters[name]": {"john"},
+			},
+		},
+		{
+			name: "not equals operator",
+			filters: func() []filter.CrudFilter {
+				return []filter.CrudFilter{
+					filter.NewLogicalFilter("age", filter.OpNe, 20),
+				}
+			},
+			expected: map[string][]string{
+				"filters[age][ne]": {"20"},
+			},
+		},
+		{
+			name: "contains operator",
+			filters: func() []filter.CrudFilter {
+				return []filter.CrudFilter{
+					filter.NewLogicalFilter("title", filter.OpContains, "test"),
+				}
+			},
+			expected: map[string][]string{
+				"filters[title][contains]": {"test"},
+			},
+		},
+		{
+			name: "nested conditional filters",
+			filters: func() []filter.CrudFilter {
+				return []filter.CrudFilter{
+					filter.NewConditionalFilter(filter.LogicalOr, []filter.CrudFilter{
+						filter.NewLogicalFilter("name", filter.OpEq, "john"),
+						filter.NewLogicalFilter("age", filter.OpGte, 30),
+					}),
+				}
+			},
+			expected: map[string][]string{
+				"filters[or][0][name]":     {"john"},
+				"filters[or][1][age][gte]": {"30"},
+			},
+		},
+		{
+			name: "global search",
+			filters: func() []filter.CrudFilter {
+				return []filter.CrudFilter{
+					filter.NewLogicalFilter("q", filter.OpEq, "searchterm"),
+				}
+			},
+			expected: map[string][]string{
+				"q": {"searchterm"},
+			},
+		},
+		{
+			name: "numeric value types",
+			filters: func() []filter.CrudFilter {
+				return []filter.CrudFilter{
+					filter.NewLogicalFilter("age", filter.OpEq, 25),
+					filter.NewLogicalFilter("price", filter.OpGte, 19.99),
+				}
+			},
+			expected: map[string][]string{
+				"filters[age]":        {"25"},
+				"filters[price][gte]": {"19.99"},
+			},
+		},
+		{
+			name: "between operator with explicit float values",
+			filters: func() []filter.CrudFilter {
+				return []filter.CrudFilter{
+					filter.Between("price", 10.0, 20.0), // Explicit float values
+				}
+			},
+			expected: map[string][]string{
+				"filters[price][between]": {"10", "20"}, // Strings are ok here since they'll be parsed as numbers
+			},
+		},
+		{
+			name: "multiple values for in operator",
+			filters: func() []filter.CrudFilter {
+				return []filter.CrudFilter{
+					filter.NewLogicalFilter("id", filter.OpIn, []any{1, 2, 3}),
+				}
+			},
+			expected: map[string][]string{
+				"filters[id][in]": {"1", "2", "3"},
+			},
+		},
+		{
+			name: "null operator",
+			filters: func() []filter.CrudFilter {
+				return []filter.CrudFilter{
+					filter.NewLogicalFilter("deleted_at", filter.OpNull, nil),
+				}
+			},
+			expected: map[string][]string{
+				"filters[deleted_at][null]": {""},
+			},
+		},
+		{
+			name: "not null operator",
+			filters: func() []filter.CrudFilter {
+				return []filter.CrudFilter{
+					filter.NewLogicalFilter("updated_at", filter.OpNnull, nil),
+				}
+			},
+			expected: map[string][]string{
+				"filters[updated_at][nnull]": {""},
+			},
+		},
+		{
+			name: "complex nested filters",
+			filters: func() []filter.CrudFilter {
+				return []filter.CrudFilter{
+					filter.NewConditionalFilter(filter.LogicalAnd, []filter.CrudFilter{
+						filter.NewLogicalFilter("status", filter.OpEq, "active"),
+						filter.NewConditionalFilter(filter.LogicalOr, []filter.CrudFilter{
+							filter.NewLogicalFilter("age", filter.OpGte, 18),
+							filter.NewLogicalFilter("vip", filter.OpEq, true),
+						}),
+					}),
+				}
+			},
+			expected: map[string][]string{
+				"filters[and][0][status]":          {"active"},
+				"filters[and][1][or][0][age][gte]": {"18"},
+				"filters[and][1][or][1][vip]":      {"true"},
+			},
+		},
+		{
+			name: "invalid between operator",
+			filters: func() (filters []filter.CrudFilter) {
+				filters = []filter.CrudFilter{
+					filter.NewLogicalFilter("price", filter.OpBetween, []any{10}),
+				}
+				return filters
+			},
+			wantErr: true,
+		},
+	}
+
+	generator := NewDefaultQueryParamGenerator()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var filters []filter.CrudFilter
+			var err error
+			if tt.filters != nil {
+				defer func() {
+					if r := recover(); r != nil {
+						if !tt.wantErr {
+							assert.Fail(t, "Unexpected panic", "Panic: %v", r)
+						}
+					}
+				}()
+				filters = tt.filters()
+			}
+			result, err := generator.Generate(filters)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
- Added new query parameter generator package with DefaultQueryParamGenerator implementation
- Replaced lo.Invert dependency with custom OperatorReverseMap implementation
  - Added thread-safe initialization with sorted keys for determinism
  - Added mutex protection for concurrent access
- Added comprehensive test cases for query parameter generation
- Maintained backward compatibility with existing operator string representations

The generator converts CrudFilter structures into URL query parameters following a standardized format, supporting both logical and conditional filters with proper nesting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to convert complex filters into URL query parameters, supporting nested logical conditions, various operators, and proper encoding.
- **Bug Fixes**
  - Improved thread safety and deterministic ordering when handling operator mappings.
- **Tests**
  - Introduced comprehensive tests to ensure correct and robust query parameter generation from different filter scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->