### PR TITLE
feat: add URL query string utility functions

### DIFF
--- a/query.go
+++ b/query.go
@@ -1,0 +1,50 @@
+package queryutil
+
+import (
+	"net/url"
+	"sort"
+	"strings"
+)
+
+// ToQueryString converts a map of query parameters to a URL-encoded query string.
+// The keys are sorted alphabetically to ensure consistent output.
+// Example:
+//
+//	params := map[string][]string{
+//	    "name": {"john"},
+//	    "age":  {"30"},
+//	}
+//
+// query := queryutil.ToQueryString(params) // "age=30&name=john"
+func ToQueryString(params map[string][]string) string {
+	if len(params) == 0 {
+		return ""
+	}
+
+	// Get sorted keys for consistent output
+	keys := make([]string, 0, len(params))
+	for k := range params {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var buf strings.Builder
+	for _, key := range keys {
+		values := params[key]
+		keyEscaped := url.QueryEscape(key)
+
+		for _, value := range values {
+			if buf.Len() > 0 {
+				buf.WriteByte('&')
+			}
+			buf.WriteString(keyEscaped)
+			if value != "" { // Only write =value if value is not empty
+				buf.WriteByte('=')
+				buf.WriteString(url.QueryEscape(value))
+			}
+
+		}
+	}
+
+	return buf.String()
+}

--- a/query_test.go
+++ b/query_test.go
@@ -1,0 +1,74 @@
+package queryutil
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestToQueryString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    map[string][]string
+		expected string
+	}{
+		{
+			name:     "empty map",
+			input:    map[string][]string{},
+			expected: "",
+		},
+		{
+			name: "single key-value pair",
+			input: map[string][]string{
+				"name": {"john"},
+			},
+			expected: "name=john",
+		},
+		{
+			name: "multiple values for same key",
+			input: map[string][]string{
+				"id": {"1", "2", "3"},
+			},
+			expected: "id=1&id=2&id=3",
+		},
+		{
+			name: "multiple key-value pairs",
+			input: map[string][]string{
+				"name":  {"john"},
+				"age":   {"30"},
+				"email": {"john@example.com"},
+			},
+			expected: "age=30&email=john%40example.com&name=john",
+		},
+		{
+			name: "empty value",
+			input: map[string][]string{
+				"flag": {""},
+				"name": {"john"},
+			},
+			expected: "flag&name=john",
+		},
+		{
+			name: "special characters in values",
+			input: map[string][]string{
+				"query": {"hello world"},
+				"email": {"user@example.com"},
+			},
+			expected: "email=user%40example.com&query=hello+world",
+		},
+		{
+			name: "special characters in keys",
+			input: map[string][]string{
+				"user name": {"john doe"},
+				"age":       {"30"},
+			},
+			expected: "age=30&user+name=john+doe",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ToQueryString(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
Add ToQueryString function to convert map[string][]string to URL-encoded query string with:
- Consistent sorted key ordering
- Proper URL encoding of keys and values
- Support for empty values
- Multiple values per key

Add comprehensive test cases covering:
- Empty map
- Single/multiple key-value pairs
- Special characters
- Empty values
- Multiple values per key

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to convert key-value pairs into a URL-encoded query string.
- **Tests**
  - Introduced comprehensive tests to ensure correct conversion of key-value pairs into query strings, including handling of empty values and special characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->