### PR TITLE
feat: add time string parsing support and validation

### DIFF
--- a/filter/query_builder.go
+++ b/filter/query_builder.go
@@ -7,6 +7,29 @@ import (
 	"time"
 )
 
+var timeFormats = []string{
+	time.RFC3339,
+	"2006-01-02 15:04:05",                 // Basic datetime format
+	"2006-01-02",                          // Basic date format
+	"2006-01-02 15:04:05.999999999+00:00", // Common MySQL format with nanoseconds
+	"2006-01-02 15:04:05+00:00",           // MySQL format without nanoseconds
+	"2006-01-02 15:04:05.999999999",       // Without timezone
+	"2006-01-02 15:04:05.999999999 -0700 MST m=+0.000000000", // Go debug format with nanoseconds
+	"2006-01-02 15:04:05 -0700 MST m=+0.000000000",           // Go debug format without nanoseconds
+	"2006-01-02 15:04:05 -0700 MST",                          // Shorter Go debug format
+}
+
+// ParseTime attempts to parse a time string using multiple common formats
+func ParseTime(timeStr string) (time.Time, error) {
+	for _, format := range timeFormats {
+		t, err := time.Parse(format, timeStr)
+		if err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("failed to parse time '%s' with any known format", timeStr)
+}
+
 // Core predicate functions
 
 // Equal creates a 'field equals value' filter
@@ -533,10 +556,20 @@ func validateNumericOrTimeType(field string, value any) {
 	if isNumeric(value) {
 		return
 	}
+
+	// Check for time.Time directly
 	if _, ok := value.(time.Time); ok {
 		return
 	}
-	panic(fmt.Sprintf("%s: value must be numeric or time.Time, got %T", field, value))
+
+	// Try to parse string as time
+	if strVal, ok := value.(string); ok {
+		if _, err := ParseTime(strVal); err == nil {
+			return
+		}
+	}
+
+	panic(fmt.Sprintf("%s: value must be numeric, time.Time, or parseable time string, got %T (%v)", field, value, value))
 }
 
 func validateNumericPair(field string, value any) {

--- a/filter/query_builder_test.go
+++ b/filter/query_builder_test.go
@@ -8,6 +8,83 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestValidateNumericOrTimeType(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   any
+		wantErr bool
+	}{
+		{
+			name:    "valid numeric int",
+			value:   42,
+			wantErr: false,
+		},
+		{
+			name:    "valid numeric float",
+			value:   3.14,
+			wantErr: false,
+		},
+		{
+			name:    "valid time.Time",
+			value:   time.Now(),
+			wantErr: false,
+		},
+		{
+			name:    "valid RFC3339 time string",
+			value:   "2025-06-09T12:34:56Z",
+			wantErr: false,
+		},
+		{
+			name:    "valid MySQL datetime string",
+			value:   "2025-06-09 12:34:56.789",
+			wantErr: false,
+		},
+		{
+			name:    "valid date string",
+			value:   "2025-06-09",
+			wantErr: false,
+		},
+		{
+			name:    "valid Go debug time string",
+			value:   time.Now().String(), // Generates current time in Go debug format
+			wantErr: false,
+		},
+		{
+			name:    "valid timezone-aware string",
+			value:   "2025-06-09T12:34:56+02:00",
+			wantErr: false,
+		},
+		{
+			name:    "invalid string",
+			value:   "not a time",
+			wantErr: true,
+		},
+		{
+			name:    "invalid type",
+			value:   []int{1, 2, 3},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					if !tt.wantErr {
+						t.Errorf("validateNumericOrTimeType() panicked unexpectedly: %v", r)
+					}
+				}
+			}()
+
+			validateNumericOrTimeType("test_field", tt.value)
+
+			if tt.wantErr {
+				t.Error("validateNumericOrTimeType() should have panicked but didn't")
+			}
+		})
+	}
+}
+
 func TestQueryBuilderFunctions(t *testing.T) {
 	t.Run("EqualityFilters", func(t *testing.T) {
 		tests := []struct {


### PR DESCRIPTION
- Added ParseTime function with support for multiple common time formats including RFC3339, MySQL datetime, and Go debug formats
- Enhanced validateNumericOrTimeType to accept parseable time strings in addition to numeric/time.Time values
- Added comprehensive tests for time string validation
- Improved error messages to include value details when validation fails

The changes allow filters to accept time values as properly formatted strings, making the API more flexible while maintaining type safety.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced validation to support a broader range of date and time string formats.
- **Tests**
  - Added tests to verify validation of numeric values, time objects, and multiple time string formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->