### PR TITLE
fix: properly format time values in query parameters

### DIFF
--- a/filter/generator/generator.go
+++ b/filter/generator/generator.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
+	"time"
 
 	"github.com/samber/lo"
 	"go.lumeweb.com/queryutil/filter"
@@ -115,28 +116,40 @@ func (g *queryGenerator) processConditionalFilter(f *filter.ConditionalFilter, p
 
 // getFilterValues converts filter values to URL-encoded strings
 func (g *queryGenerator) getFilterValues(f *filter.LogicalFilter) ([]string, error) {
+	formatValue := func(v any) string {
+		if t, ok := v.(time.Time); ok {
+			return t.Format(time.RFC3339)
+		}
+		return fmt.Sprint(v)
+	}
+
 	switch val := f.Value().(type) {
 	case []any: // For "in" and "between"
 		if f.Operator() == filter.OpBetween || f.Operator() == filter.OpNbetween {
 			if len(val) != 2 {
 				return nil, fmt.Errorf("between operator requires exactly 2 values")
 			}
-			// Validate between values are numeric before encoding
-			if _, err := strconv.ParseFloat(fmt.Sprint(val[0]), 64); err != nil {
-				return nil, fmt.Errorf("between operator requires numeric values")
-			}
-			if _, err := strconv.ParseFloat(fmt.Sprint(val[1]), 64); err != nil {
-				return nil, fmt.Errorf("between operator requires numeric values")
+			// Skip numeric validation if values are time.Time
+			_, isTime1 := val[0].(time.Time)
+			_, isTime2 := val[1].(time.Time)
+			if !isTime1 && !isTime2 {
+				// Validate between values are numeric if not time.Time
+				if _, err := strconv.ParseFloat(formatValue(val[0]), 64); err != nil {
+					return nil, fmt.Errorf("between operator requires numeric or time values")
+				}
+				if _, err := strconv.ParseFloat(formatValue(val[1]), 64); err != nil {
+					return nil, fmt.Errorf("between operator requires numeric or time values")
+				}
 			}
 		}
 		values := lo.Map(val, func(item any, _ int) string {
-			return url.QueryEscape(fmt.Sprint(item))
+			return url.QueryEscape(formatValue(item))
 		})
 		return values, nil
 	case nil: // For null/nnull operators
 		return []string{""}, nil
 	default:
-		return []string{url.QueryEscape(fmt.Sprint(f.Value()))}, nil
+		return []string{url.QueryEscape(formatValue(f.Value()))}, nil
 	}
 }
 


### PR DESCRIPTION
The generator now correctly formats time.Time values as RFC3339 strings when converting filter values to URL query parameters. Previously, time values were being formatted using the default String() representation.

Added a formatValue helper function that handles time.Time values specially, ensuring consistent RFC3339 formatting for temporal values in generated URLs.

This ensures proper interoperability with servers expecting RFC3339 formatted timestamps in query parameters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency in how date and time values are formatted when filters are applied, ensuring all time values use the RFC3339 standard. This enhances reliability when filtering by dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->