### PR TITLE
feat(builder): implement JSON field filtering for GORMBuilder

### DIFF
--- a/filter/builder/db_clause.go
+++ b/filter/builder/db_clause.go
@@ -1,6 +1,9 @@
 package builder
 
-import "go.lumeweb.com/queryutil/filter"
+import (
+	"go.lumeweb.com/queryutil/filter"
+	"gorm.io/gorm"
+)
 
 // CompoundClause represents a logical combination of clauses (e.g., AND, OR, NOT).
 // It's an internal representation built by the visitor methods.
@@ -45,5 +48,23 @@ func NewSQLClause(query string, field string, params ...any) *SQLClause {
 }
 
 func (sc *SQLClause) Type() filter.ClauseType {
+	return filter.WhereClauseType
+}
+
+// GormConditionClause represents a pre-built GORM condition.
+// This is used for complex conditions like JSON queries that need special handling.
+type GormConditionClause struct {
+	Condition *gorm.DB // The GORM DB query object representing the condition
+	Field     string   // The field name (e.g., "metadata.total_steps")
+}
+
+func NewGormConditionClause(condition *gorm.DB, field string) *GormConditionClause {
+	return &GormConditionClause{
+		Condition: condition,
+		Field:     field,
+	}
+}
+
+func (gcc *GormConditionClause) Type() filter.ClauseType {
 	return filter.WhereClauseType
 }

--- a/filter/builder/gorm_builder.go
+++ b/filter/builder/gorm_builder.go
@@ -2,8 +2,10 @@ package builder
 
 import (
 	"fmt"
+	"strings"
 
 	"go.lumeweb.com/queryutil/filter"
+	"gorm.io/datatypes"
 	"gorm.io/gorm"
 )
 
@@ -116,6 +118,9 @@ func (b *GORMBuilder) buildClauseCondition(clause filter.Clause) (*gorm.DB, erro
 			// All other standard operators expect parameters spread variadically
 			return conditionBuilderDB.Where(fmt.Sprintf("%s %s", c.Field, c.Query), c.Params...), nil
 		}
+	case *GormConditionClause:
+		// For pre-built GORM conditions, just return the condition as is
+		return c.Condition, nil
 	case *CompoundClause:
 		switch c.Operator {
 		case filter.LogicalAnd:
@@ -190,6 +195,11 @@ func (b *GORMBuilder) VisitLogical(f *filter.LogicalFilter) (filter.Clause, erro
 		}
 
 		return NewCompoundClause(filter.LogicalOr, clauses), nil
+	}
+
+	// Check if this is a JSON path field (contains dot notation)
+	if isJSONPath(f.Field()) {
+		return b.buildJSONClause(f)
 	}
 
 	// For all other logical filters, build a single SQL clause
@@ -270,4 +280,89 @@ func formatValue(op filter.Operator, value any) any {
 
 	// For all other operators (Eq, Ne, Lt, Gt, Lte, Gte, In, Nin), return the value as is.
 	return value
+}
+
+// isJSONPath checks if a field name represents a JSON path (contains dot notation)
+func isJSONPath(field string) bool {
+	return strings.Contains(field, ".")
+}
+
+// parseJSONPath splits a JSON path field into column name and path components
+func parseJSONPath(field string) (jsonColumn, jsonPath string) {
+	parts := strings.SplitN(field, ".", 2)
+	return parts[0], parts[1]
+}
+
+// buildJSONQuery creates a JSON query expression for the given operator and parameters
+func (b *GORMBuilder) buildJSONQuery(operator, jsonColumn, jsonPath string, value any) (string, []any) {
+	// For SQLite, use json_extract()
+	// For MySQL, use JSON_EXTRACT()
+	extractFunc := "JSON_EXTRACT"
+	if b.baseTx.Dialector.Name() == "sqlite" {
+		extractFunc = "json_extract"
+	}
+
+	query := fmt.Sprintf("%s(%s, ?) %s ?", extractFunc, jsonColumn, operator)
+	params := []any{"$." + jsonPath, value}
+
+	return query, params
+}
+
+// buildJSONClause creates a GORM condition for JSON path fields
+func (b *GORMBuilder) buildJSONClause(f *filter.LogicalFilter) (filter.Clause, error) {
+	jsonColumn, jsonPath := parseJSONPath(f.Field())
+
+	// Create a new session for building the JSON query
+	conditionBuilderDB := b.baseTx.Session(&gorm.Session{NewDB: true})
+
+	// Handle different operators using datatypes.JSONQuery methods
+	switch f.Operator() {
+	case filter.OpEq:
+		condition := conditionBuilderDB.Where(datatypes.JSONQuery(jsonColumn).Equals(f.Value(), jsonPath))
+		return NewGormConditionClause(condition, f.Field()), nil
+	case filter.OpNe:
+		condition := conditionBuilderDB.Where(b.buildJSONQuery("<> ?", jsonColumn, jsonPath, f.Value()))
+		return NewGormConditionClause(condition, f.Field()), nil
+	case filter.OpGt:
+		query, params := b.buildJSONQuery(">", jsonColumn, jsonPath, f.Value())
+		return NewSQLClause(query, "", params...), nil
+	case filter.OpGte:
+		query, params := b.buildJSONQuery(">=", jsonColumn, jsonPath, f.Value())
+		return NewSQLClause(query, "", params...), nil
+	case filter.OpLt:
+		query, params := b.buildJSONQuery("<", jsonColumn, jsonPath, f.Value())
+		return NewSQLClause(query, "", params...), nil
+	case filter.OpLte:
+		query, params := b.buildJSONQuery("<=", jsonColumn, jsonPath, f.Value())
+		return NewSQLClause(query, "", params...), nil
+	case filter.OpNull:
+		condition := conditionBuilderDB.Where("? IS NULL", datatypes.JSONQuery(jsonColumn).Extract(jsonPath))
+		return NewGormConditionClause(condition, f.Field()), nil
+	case filter.OpNnull:
+		condition := conditionBuilderDB.Where("? IS NOT NULL", datatypes.JSONQuery(jsonColumn).Extract(jsonPath))
+		return NewGormConditionClause(condition, f.Field()), nil
+	default:
+		// For pattern matching operators, we need to handle them specially
+		switch f.Operator() {
+		case filter.OpContains, filter.OpContainss:
+			condition := conditionBuilderDB.Where(datatypes.JSONQuery(jsonColumn).Likes(fmt.Sprintf("%%%v%%", f.Value()), jsonPath))
+			return NewGormConditionClause(condition, f.Field()), nil
+		case filter.OpNcontains, filter.OpNcontainss:
+			// For NOT LIKE operations, we need to negate the LIKE condition
+			jsonQuery := datatypes.JSONQuery(jsonColumn).Likes(fmt.Sprintf("%%%v%%", f.Value()), jsonPath)
+			condition := conditionBuilderDB.Where("NOT (?)", jsonQuery)
+			return NewGormConditionClause(condition, f.Field()), nil
+		case filter.OpStartswith, filter.OpStartswiths, filter.OpNstartswith, filter.OpNstartswiths:
+			// Handle startswith by using LIKE with appropriate pattern
+			condition := conditionBuilderDB.Where(datatypes.JSONQuery(jsonColumn).Likes(fmt.Sprintf("%v%%", f.Value()), jsonPath))
+			return NewGormConditionClause(condition, f.Field()), nil
+		case filter.OpEndswith, filter.OpEndswiths, filter.OpNendswith, filter.OpNendswiths:
+			// Handle endswith by using LIKE with appropriate pattern
+			condition := conditionBuilderDB.Where(datatypes.JSONQuery(jsonColumn).Likes(fmt.Sprintf("%%%v", f.Value()), jsonPath))
+			return NewGormConditionClause(condition, f.Field()), nil
+		default:
+			// If we get here, the operator is not supported for JSON fields
+			return nil, fmt.Errorf("unsupported operator for JSON field: %s", f.Operator())
+		}
+	}
 }

--- a/filter/builder/gorm_builder_test.go
+++ b/filter/builder/gorm_builder_test.go
@@ -1,23 +1,27 @@
 package builder
 
 import (
-	"github.com/stretchr/testify/assert"
-	"go.lumeweb.com/queryutil/filter"
-	"gorm.io/driver/sqlite"
-	"gorm.io/gorm"
 	"sort"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.lumeweb.com/queryutil/filter"
+	"gorm.io/datatypes"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
 )
 
 func TestGORMBuilder_ApplyFilters(t *testing.T) {
 	type User struct {
-		ID      uint
-		Name    string
-		Email   string
-		Bio     string
-		Age     int
-		Status  string
-		Deleted bool
+		ID       uint
+		Name     string
+		Email    string
+		Bio      string
+		Age      int
+		Status   string
+		Deleted  bool
+		Metadata datatypes.JSON
 	}
 
 	// Open database connection with logger
@@ -25,25 +29,156 @@ func TestGORMBuilder_ApplyFilters(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if sqlDB, cerr := db.DB(); cerr == nil {
+		t.Cleanup(func() { _ = sqlDB.Close() })
+	}
 
 	err = db.AutoMigrate(&User{})
 	if err != nil {
 		t.Fatal(err) // Changed from t.Error to t.Fatal as migration failure is critical
 	}
 
-	// Seed data
-	db.Create(&User{Name: "John Doe", Email: "john@example.com", Bio: "Developer", Age: 35, Status: "active", Deleted: false})
-	db.Create(&User{Name: "Jane Smith", Email: "jane@example.com", Bio: "Designer", Age: 25, Status: "inactive", Deleted: false})
-	db.Create(&User{Name: "Peter Jones", Email: "peter@test.com", Bio: "Consultant", Age: 40, Status: "active", Deleted: true}) // Added a third user for better testing
+	// Seed data with proper JSON construction and error checking
+	result := db.Create(&User{
+		Name:     "John Doe",
+		Email:    "john@example.com",
+		Bio:      "Developer",
+		Age:      35,
+		Status:   "active",
+		Deleted:  false,
+		Metadata: datatypes.JSON([]byte(`{"total_steps": 10000, "preferences": {"theme": "dark"}, "tags": ["admin", "user"]}`)),
+	})
+	require.NoError(t, result.Error)
+
+	result = db.Create(&User{
+		Name:     "Jane Smith",
+		Email:    "jane@example.com",
+		Bio:      "Designer",
+		Age:      25,
+		Status:   "inactive",
+		Deleted:  false,
+		Metadata: datatypes.JSON([]byte(`{"total_steps": 5000, "preferences": {"theme": "light"}, "tags": ["user"]}`)),
+	})
+	require.NoError(t, result.Error)
+
+	result = db.Create(&User{
+		Name:     "Peter Jones",
+		Email:    "peter@test.com",
+		Bio:      "Consultant",
+		Age:      40,
+		Status:   "active",
+		Deleted:  true,
+		Metadata: datatypes.JSON([]byte(`{"total_steps": 15000, "preferences": {"theme": "dark"}, "tags": ["admin", "premium"]}`)),
+	})
+	require.NoError(t, result.Error)
 
 	tests := []struct {
 		name         string
 		filters      []filter.CrudFilter // Now defined using constructors
 		searchConfig *filter.GlobalSearchConfig
 		wantCount    int64
+		wantErr      bool // Explicitly indicate whether an error is expected
 		// Optional: Add a function to verify specific results if needed beyond count
 		verify func(*testing.T, []User)
 	}{
+		{
+			name: "json equality filter",
+			filters: []filter.CrudFilter{
+				filter.NewLogicalFilter("metadata.total_steps", filter.OpEq, 10000),
+			},
+			searchConfig: nil,
+			wantCount:    1,
+			verify: func(t *testing.T, users []User) {
+				if assert.Len(t, users, 1) {
+					assert.Equal(t, "John Doe", users[0].Name)
+				}
+			},
+		},
+		{
+			name: "json array contains filter",
+			filters: []filter.CrudFilter{
+				filter.NewLogicalFilter("metadata.tags", filter.OpContains, "admin"),
+			},
+			searchConfig: nil,
+			wantCount:    2, // John Doe and Peter Jones have "admin" tag
+			wantErr:      false,
+			verify: func(t *testing.T, users []User) {
+				sort.SliceStable(users, func(i, j int) bool {
+					return users[i].Name < users[j].Name
+				})
+				assert.Len(t, users, 2)
+				assert.Equal(t, "John Doe", users[0].Name)
+				assert.Equal(t, "Peter Jones", users[1].Name)
+			},
+		},
+		{
+			name: "json greater than filter",
+			filters: []filter.CrudFilter{
+				filter.NewLogicalFilter("metadata.total_steps", filter.OpGt, 10000),
+			},
+			searchConfig: nil,
+			wantCount:    1, // Only Peter Jones (15000)
+			verify: func(t *testing.T, users []User) {
+				if assert.Len(t, users, 1) {
+					assert.Equal(t, "Peter Jones", users[0].Name)
+				}
+			},
+		},
+		{
+			name: "json less than filter",
+			filters: []filter.CrudFilter{
+				filter.NewLogicalFilter("metadata.total_steps", filter.OpLt, 10000),
+			},
+			searchConfig: nil,
+			wantCount:    1, // Only Jane Smith (5000)
+			verify: func(t *testing.T, users []User) {
+				if assert.Len(t, users, 1) {
+					assert.Equal(t, "Jane Smith", users[0].Name)
+				}
+			},
+		},
+		{
+			name: "json contains filter",
+			filters: []filter.CrudFilter{
+				filter.NewLogicalFilter("metadata.preferences.theme", filter.OpContains, "dark"),
+			},
+			searchConfig: nil,
+			wantCount:    2, // John Doe and Peter Jones
+			verify: func(t *testing.T, users []User) {
+				sort.SliceStable(users, func(i, j int) bool {
+					return users[i].Name < users[j].Name
+				})
+				assert.Len(t, users, 2)
+				assert.Equal(t, "John Doe", users[0].Name)
+				assert.Equal(t, "Peter Jones", users[1].Name)
+			},
+		},
+		{
+			name: "json not contains filter",
+			filters: []filter.CrudFilter{
+				filter.NewLogicalFilter("metadata.preferences.theme", filter.OpNcontains, "dark"),
+			},
+			searchConfig: nil,
+			wantCount:    1, // Only Jane Smith (light theme)
+			verify: func(t *testing.T, users []User) {
+				if assert.Len(t, users, 1) {
+					assert.Equal(t, "Jane Smith", users[0].Name)
+				}
+			},
+		},
+		{
+			name: "json not contains case-sensitive filter",
+			filters: []filter.CrudFilter{
+				filter.NewLogicalFilter("metadata.preferences.theme", filter.OpNcontainss, "Dark"),
+			},
+			searchConfig: nil,
+			wantCount:    1, // Only Jane Smith (light theme) - case sensitive so "dark" != "Dark"
+			verify: func(t *testing.T, users []User) {
+				if assert.Len(t, users, 1) {
+					assert.Equal(t, "Jane Smith", users[0].Name)
+				}
+			},
+		},
 		{
 			name: "global search across multiple columns",
 			filters: []filter.CrudFilter{
@@ -205,6 +340,22 @@ func TestGORMBuilder_ApplyFilters(t *testing.T) {
 			wantCount:    3, // All users have a non-null Age
 		},
 		{
+			name: "json null filter",
+			filters: []filter.CrudFilter{
+				filter.NewLogicalFilter("metadata.missing_field", filter.OpNull, nil),
+			},
+			searchConfig: nil,
+			wantCount:    3, // All users as missing_field does not exist
+		},
+		{
+			name: "json not null filter",
+			filters: []filter.CrudFilter{
+				filter.NewLogicalFilter("metadata.total_steps", filter.OpNnull, nil),
+			},
+			searchConfig: nil,
+			wantCount:    3, // All users have total_steps
+		},
+		{
 			name: "deleted boolean filter",
 			filters: []filter.CrudFilter{
 				filter.NewLogicalFilter("Deleted", filter.OpEq, true),
@@ -272,12 +423,22 @@ func TestGORMBuilder_ApplyFilters(t *testing.T) {
 		// Add more tests for other operators (gt, lt, gte, lte, nin, nbetween, etc.)
 		// and more complex combinations.
 		{
+			name: "json field with explicit null value",
+			filters: []filter.CrudFilter{
+				filter.NewLogicalFilter("metadata.nullable_field", filter.OpNull, nil),
+			},
+			searchConfig: nil,
+			wantCount:    0, // Assuming no users have explicit null in their JSON
+			wantErr:      false,
+		},
+		{
 			name: "greater than filter",
 			filters: []filter.CrudFilter{
 				filter.NewLogicalFilter("Age", filter.OpGt, 35),
 			},
 			searchConfig: nil,
 			wantCount:    1, // Peter Jones (40)
+			wantErr:      false,
 			verify: func(t *testing.T, users []User) {
 				assert.Len(t, users, 1)
 				assert.Equal(t, "Peter Jones", users[0].Name)
@@ -290,6 +451,7 @@ func TestGORMBuilder_ApplyFilters(t *testing.T) {
 			},
 			searchConfig: nil,
 			wantCount:    1, // Jane Smith (25)
+			wantErr:      false,
 			verify: func(t *testing.T, users []User) {
 				assert.Len(t, users, 1)
 				assert.Equal(t, "Jane Smith", users[0].Name)
@@ -302,6 +464,7 @@ func TestGORMBuilder_ApplyFilters(t *testing.T) {
 			},
 			searchConfig: nil,
 			wantCount:    2, // John Doe (35), Peter Jones (40)
+			wantErr:      false,
 			verify: func(t *testing.T, users []User) {
 				sort.SliceStable(users, func(i, j int) bool { return users[i].Name < users[j].Name })
 				assert.Len(t, users, 2)
@@ -316,6 +479,7 @@ func TestGORMBuilder_ApplyFilters(t *testing.T) {
 			},
 			searchConfig: nil,
 			wantCount:    2, // John Doe (35), Jane Smith (25)
+			wantErr:      false,
 			verify: func(t *testing.T, users []User) {
 				sort.SliceStable(users, func(i, j int) bool { return users[i].Name < users[j].Name })
 				assert.Len(t, users, 2)
@@ -330,6 +494,7 @@ func TestGORMBuilder_ApplyFilters(t *testing.T) {
 			},
 			searchConfig: nil,
 			wantCount:    1, // Peter Jones
+			wantErr:      false,
 			verify: func(t *testing.T, users []User) {
 				assert.Len(t, users, 1)
 				assert.Equal(t, "Peter Jones", users[0].Name)
@@ -342,6 +507,7 @@ func TestGORMBuilder_ApplyFilters(t *testing.T) {
 			},
 			searchConfig: nil,
 			wantCount:    2, // Jane Smith (25), Peter Jones (40)
+			wantErr:      false,
 			verify: func(t *testing.T, users []User) {
 				sort.SliceStable(users, func(i, j int) bool { return users[i].Name < users[j].Name })
 				assert.Len(t, users, 2)
@@ -354,11 +520,13 @@ func TestGORMBuilder_ApplyFilters(t *testing.T) {
 			name:      "nil filters slice",
 			filters:   nil,
 			wantCount: 3, // All users
+			wantErr:   false,
 		},
 		{
 			name:      "empty filters slice",
 			filters:   []filter.CrudFilter{},
 			wantCount: 3, // All users
+			wantErr:   false,
 		},
 		{
 			name: "conditional filter with nil filters",
@@ -366,6 +534,7 @@ func TestGORMBuilder_ApplyFilters(t *testing.T) {
 				filter.NewConditionalFilter(filter.LogicalAnd, nil),
 			},
 			wantCount: 3, // Should likely apply no condition, returning all users, or potentially error depending on builder logic
+			wantErr:   false,
 			// Assuming it applies no condition if filter list is nil/empty for conditional filters.
 			// If the builder returns an error for nil/empty filter list in a conditional, adjust wantErr=true.
 		},
@@ -375,6 +544,88 @@ func TestGORMBuilder_ApplyFilters(t *testing.T) {
 				filter.NewConditionalFilter(filter.LogicalAnd, []filter.CrudFilter{}),
 			},
 			wantCount: 3, // Should likely apply no condition
+			wantErr:   false,
+		},
+		{
+			name: "json startswith filter",
+			filters: []filter.CrudFilter{
+				filter.NewLogicalFilter("metadata.preferences.theme", filter.OpStartswith, "dar"),
+			},
+			searchConfig: nil,
+			wantCount:    2, // John Doe and Peter Jones have "dark" theme
+			wantErr:      false,
+			verify: func(t *testing.T, users []User) {
+				sort.SliceStable(users, func(i, j int) bool {
+					return users[i].Name < users[j].Name
+				})
+				assert.Len(t, users, 2)
+				assert.Equal(t, "John Doe", users[0].Name)
+				assert.Equal(t, "Peter Jones", users[1].Name)
+			},
+		},
+		{
+			name: "json endswith filter",
+			filters: []filter.CrudFilter{
+				filter.NewLogicalFilter("metadata.preferences.theme", filter.OpEndswith, "ght"),
+			},
+			searchConfig: nil,
+			wantCount:    1, // Jane Smith has "light" theme
+			wantErr:      false,
+			verify: func(t *testing.T, users []User) {
+				assert.Len(t, users, 1)
+				assert.Equal(t, "Jane Smith", users[0].Name)
+			},
+		},
+		{
+			name: "json non-existent path filter",
+			filters: []filter.CrudFilter{
+				filter.NewLogicalFilter("metadata.non_existent_field", filter.OpEq, "value"),
+			},
+			searchConfig: nil,
+			wantCount:    0, // Should return no results for non-existent paths
+			wantErr:      false,
+			verify: func(t *testing.T, users []User) {
+				assert.Empty(t, users) // Expect no results
+			},
+		},
+		{
+			name: "json field with special characters in path",
+			filters: []filter.CrudFilter{
+				filter.NewLogicalFilter("metadata.user-info", filter.OpEq, "test"),
+			},
+			searchConfig: nil,
+			wantCount:    0, // No users have user-info field
+			wantErr:      false,
+		},
+		{
+			name: "json deeply nested path filter",
+			filters: []filter.CrudFilter{
+				filter.NewLogicalFilter("metadata.preferences.theme.dark_mode", filter.OpEq, true),
+			},
+			searchConfig: nil,
+			wantCount:    0, // No users have this deeply nested field
+			wantErr:      false,
+		},
+		{
+			name: "json field with numeric keys",
+			filters: []filter.CrudFilter{
+				filter.NewLogicalFilter("metadata.123", filter.OpEq, "value"),
+			},
+			searchConfig: nil,
+			wantCount:    0, // No users have field with numeric key
+			wantErr:      false,
+		},
+		{
+			name: "json non-existent path filter",
+			filters: []filter.CrudFilter{
+				filter.NewLogicalFilter("metadata.non_existent_field", filter.OpEq, "value"),
+			},
+			searchConfig: nil,
+			wantCount:    0, // Should return no results for non-existent paths
+			wantErr:      false,
+			verify: func(t *testing.T, users []User) {
+				assert.Empty(t, users) // Expect no results
+			},
 		},
 	}
 
@@ -390,14 +641,11 @@ func TestGORMBuilder_ApplyFilters(t *testing.T) {
 			// Let's assume for now that structural errors are caught in Apply and database errors during Find.
 
 			// Check for early errors from Apply if any were introduced
-			if errApply != nil {
-				if tt.wantCount > 0 { // If we expected results, an early error is unexpected
-					assert.Fail(t, "Unexpected error from Apply", "Error: %v", errApply)
-				} else {
-					assert.Error(t, errApply)
-					// No need to query the database if Apply failed as expected
-				}
-				return // Exit the test case if Apply failed
+			if tt.wantErr {
+				assert.Error(t, errApply)
+				return // Exit the test case if Apply failed as expected
+			} else {
+				assert.NoError(t, errApply, "Apply returned unexpected error")
 			}
 
 			var users []User

--- a/go.mod
+++ b/go.mod
@@ -10,11 +10,13 @@ require (
 	github.com/stretchr/testify v1.10.0
 	go.lumeweb.com/portal-router v0.2.3
 	golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6
+	gorm.io/datatypes v1.2.5
 	gorm.io/driver/sqlite v1.5.7
 	gorm.io/gorm v1.25.12
 )
 
 require (
+	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
@@ -22,7 +24,9 @@ require (
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
+	github.com/go-sql-driver/mysql v1.9.0 // indirect
 	github.com/golang-jwt/jwt/v5 v5.2.2 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
@@ -51,6 +55,7 @@ require (
 	golang.org/x/text v0.25.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gorm.io/driver/mysql v1.5.7 // indirect
 )
 
 replace github.com/go-viper/mapstructure/v2 => github.com/LumeWeb/mapstructure/v2 v2.0.0-20241213212524-92525f5828be


### PR DESCRIPTION
- Adds support for filtering based on JSON fields using GORM's datatypes.JSONQuery.
- Introduces GormConditionClause for handling pre-built GORM conditions.
- Implements JSON path parsing and query building for various operators (Eq, Ne, Gt, Gte, Lt, Lte, Null, Nnull, Contains, Startswith, Endswith).
- Adds corresponding tests for JSON filtering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Filtering on nested JSON fields via dot notation (e.g., metadata.total_steps).
  - Supports Eq/Ne, Gt/Gte, Lt/Lte, Null/Nnull, and pattern operators (contains/startsWith/endsWith).
  - Dialect-aware JSON queries for MySQL and SQLite.
  - Accepts pre-built GORM conditions when composing filters.

- **Tests**
  - Expanded end-to-end tests covering extensive JSON-path queries, global search, and complex logical combinations.

- **Chores**
  - Added dependencies to support JSON handling and database drivers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->